### PR TITLE
Updates make dependencies for popos

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Requirements are rust >= 1.75 installed from rustup.io if the distro provided ve
 
 **popos (unsuported):**
 
-    sudo apt install cmake libinput-dev libseat-dev libclang-dev libudev-dev libclang-dev libglib2.0-dev libatkmm-1.6-dev libpangomm-1.4-dev librust-gdk-pixbuf-dev
+    sudo apt install cmake libinput-dev libseat-dev libclang-dev libudev-dev libglib2.0-dev libatkmm-1.6-dev libpangomm-1.4-dev librust-gdk-pixbuf-dev libsystemd-dev libgbm-dev libxkbcommon-dev
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     source "$HOME/.cargo/env"
     make


### PR DESCRIPTION
Thanks for this tool! I was unable to build on popos 22.04LTS without some tweaks. I'm not sure if the same applies to Ubuntu. Here's the details:

* Removed duplicate libclang-dev
* Added libsystemd-dev which was required by libseat-dev
* Added libgbm-dev and libxkbcommon-dev required to build rog-control-center