### PR TITLE
add Zenbook to asusd.rules

### DIFF
--- a/data/asusd.rules
+++ b/data/asusd.rules
@@ -7,6 +7,7 @@ ENV{DMI_FAMILY}=="*ROG*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*Zephyrus*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*Strix*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*Vivo*ook*", GOTO="asusd_start"
+ENV{DMI_FAMILY}=="*Zenbook*", GOTO="asusd_start"
 # No match so
 GOTO="asusd_end"
 


### PR DESCRIPTION
This PR updates the udev rule for Zenbooks, as https://github.com/flukejones/asusctl/issues/28 says.

Have a good day.