### PR TITLE
Bump smol to version ^2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tokio = { version = "^1.39.0", default-features = false, features = [
 ] }
 concat-idents = "^1.1"
 dirs = "^4.0"
-smol = "^1.3"
+smol = "^2.0"
 mio = "0.8.11"
 
 zbus = "4.4"


### PR DESCRIPTION
Verified that everything builds with latest smol, and that `asusctl led-mode` and `asusctl profile` have no regressions on my ROG Zephyrus G15