### PR TITLE
Add udev match for TX Gaming

### DIFF
--- a/data/asusd.rules
+++ b/data/asusd.rules
@@ -9,6 +9,7 @@ ENV{DMI_FAMILY}=="*Strix*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*Vivo*ook*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*Zenbook*", GOTO="asusd_start"
 ENV{DMI_FAMILY}=="*ProArt*", GOTO="asusd_start"
+ENV{DMI_FAMILY}=="*TX Gaming*", GOTO="asusd_start"
 # No match so
 GOTO="asusd_end"
 


### PR DESCRIPTION
TX Gaming is the China variant of the global TUF Gaming brand.

https://www.asus.com.cn/laptops/for-gaming/tuf-gaming/filter?Series=TUF-Gaming

dmidecode:

```

Handle 0x0001, DMI type 1, 27 bytes
System Information
        Manufacturer: ASUSTeK COMPUTER INC.
        Product Name: TX Gaming FA608FM_FA608FM
        Version: 1.0
        Serial Number: T4NRCX02L754174
        UUID: dbd4878d-e818-3045-a98e-6be82b94ffb3
        Wake-up Type: Power Switch
        SKU Number:  
        Family: TX Gaming
```