### PR TITLE
Update asusd.rules to have absolute path

### DIFF
--- a/data/asusd.rules
+++ b/data/asusd.rules
@@ -15,6 +15,6 @@ GOTO="asusd_end"
 
 LABEL="asusd_start"
 ACTION=="add|change", DRIVER=="asus-nb-wmi", TAG+="systemd", ENV{SYSTEMD_WANTS}="asusd.service"
-ACTION=="add|remove", DRIVER=="asus-nb-wmi", TAG+="systemd", RUN+="systemctl restart asusd.service"
+ACTION=="add|remove", DRIVER=="asus-nb-wmi", TAG+="systemd", RUN+="/usr/bin/systemctl restart asusd.service"
 
 LABEL="asusd_end"


### PR DESCRIPTION
Added the absolute path for systemctl. 
No modern distrobution installs it anywhere else.

We might want to revisit this with a "--no-block" argument that will speed up startup times a little, as udev is not blocked on this process completing. Currently left it out so that this is the smallest possible change to fix the issue of the warning in the journal.