### PR TITLE
Allow setting default profile for ac and battery

### DIFF
--- a/asusctl/src/cli_opts.rs
+++ b/asusctl/src/cli_opts.rs
@@ -74,6 +74,12 @@ pub struct ProfileCommand {
 
     #[options(meta = "", help = "set the active profile")]
     pub profile_set: Option<PlatformProfile>,
+
+    #[options(short = "a", meta = "", help = "set the profile to use on AC power")]
+    pub profile_set_ac: Option<PlatformProfile>,
+
+    #[options(short = "b", meta = "", help = "set the profile to use on battery power")]
+    pub profile_set_bat: Option<PlatformProfile>,
 }
 
 #[derive(Options)]

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -979,7 +979,8 @@ fn handle_throttle_profile(
         return Err(ProfileError::NotSupported.into());
     }
 
-    if !cmd.next && !cmd.list && cmd.profile_set.is_none() && !cmd.profile_get {
+    if !cmd.next && !cmd.list && cmd.profile_set.is_none() && !cmd.profile_get && cmd.profile_set_ac.is_none() && cmd.profile_set_bat.is_none()
+    {
         if !cmd.help {
             println!("Missing arg or command\n");
         }
@@ -999,6 +1000,10 @@ fn handle_throttle_profile(
         proxy.set_platform_profile(PlatformProfile::next(current, &choices))?;
     } else if let Some(profile) = cmd.profile_set {
         proxy.set_platform_profile(profile)?;
+    } else if let Some(profile) = cmd.profile_set_ac {
+        proxy.set_platform_profile_on_ac(profile)?;
+    } else if let Some(profile) = cmd.profile_set_bat {
+        proxy.set_platform_profile_on_battery(profile)?;
     }
 
     if cmd.list {
@@ -1009,6 +1014,8 @@ fn handle_throttle_profile(
 
     if cmd.profile_get {
         println!("Active profile is {current:?}");
+        println!("Profile on AC is {:?}", proxy.platform_profile_on_ac()?);
+        println!("Profile on Battery is {:?}", proxy.platform_profile_on_battery()?);
     }
 
     Ok(())


### PR DESCRIPTION
This PR adds options:

```sh
asusctl profile -a Performance
asusctl profile -b Quiet
```

which override the default `Quiet` and `Performance` profiles on battery and ac respectfully