### PR TITLE
Add FA617XS Backlight mode support

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -45,6 +45,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "FA617XS",
+        product_id: "",
+        layout_name: "fx505d",
+        basic_modes: [Static, Breathe, Strobing],
+        basic_zones: [],
+        advanced_type: None,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "FX505",
         product_id: "",
         layout_name: "fx505d",

--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -48,7 +48,7 @@
         device_name: "FA617XS",
         product_id: "",
         layout_name: "fx505d",
-        basic_modes: [Static, Breathe, Strobing],
+        basic_modes: [Static, Breathe, Pulse],
         basic_zones: [],
         advanced_type: None,
         power_zones: [Keyboard],


### PR DESCRIPTION
### Summary
Adds support for the ASUS TUF Gaming A16 (FA617XS, AMD Advantage Edition) keyboard lighting.

### Description
The FA617XS shares the same EC layout and single-zone backlight configuration as the FA617NS.  
Adding the following entry to `aura_support.ron` enables LED mode control (Static, Breathe, Pulse) via `asusctl`:

```ron
(
    device_name: "FA617XS",
    product_id: "",
    layout_name: "fx505d",
    basic_modes: [Static, Breathe, Pulse],
    basic_zones: [],
    advanced_type: None,
    power_zones: [Keyboard],
),
```

### Related issue

Closes #96 
