### PR TITLE
Feat: add aura support for FA608UH

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -36,6 +36,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "FA608UH",
+        product_id: "",
+        layout_name: "fa608",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Pulse, Flash],
+        basic_zones: [],
+        advanced_type: r#None,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "FA617NS",
         product_id: "",
         layout_name: "fa507",


### PR DESCRIPTION
Added support for FA608UH, which is missing. after manually testing all modes, only those that i added to file work