### PR TITLE
Fix: bidirectional Quiet<->LowPower fallback in platform_profile setters

### DIFF
--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -280,25 +280,32 @@ impl CtrlPlatform {
             self.config.lock().await.platform_profile_on_battery
         };
 
-        // Older configs may still contain Quiet on devices that only support LowPower.
+        // Configs may contain a profile name (Quiet or LowPower) that this
+        // platform does not expose via the kernel ACPI sysfs — different ASUS
+        // platforms expose one or the other for the same semantic profile.
         // Normalize at apply-time so AC/BAT transitions still work correctly.
-        if configured == PlatformProfile::Quiet {
+        let alias = match configured {
+            PlatformProfile::Quiet => Some(PlatformProfile::LowPower),
+            PlatformProfile::LowPower => Some(PlatformProfile::Quiet),
+            _ => None,
+        };
+        if let Some(target) = alias {
             if let Ok(choices) = self.platform.get_platform_profile_choices() {
-                if !choices.contains(&PlatformProfile::Quiet)
-                    && choices.contains(&PlatformProfile::LowPower)
-                {
+                if !choices.contains(&configured) && choices.contains(&target) {
                     let mut cfg = self.config.lock().await;
                     if power_plugged {
-                        cfg.platform_profile_on_ac = PlatformProfile::LowPower;
+                        cfg.platform_profile_on_ac = target;
                     } else {
-                        cfg.platform_profile_on_battery = PlatformProfile::LowPower;
+                        cfg.platform_profile_on_battery = target;
                     }
                     cfg.write();
                     warn!(
-                        "Configured profile Quiet is unavailable, falling back to LowPower for {}",
+                        "Configured profile {:?} is unavailable, falling back to {:?} for {}",
+                        configured,
+                        target,
                         if power_plugged { "AC" } else { "battery" }
                     );
-                    return PlatformProfile::LowPower;
+                    return target;
                 }
             }
         }
@@ -535,12 +542,36 @@ impl CtrlPlatform {
             self.config.lock().await.write();
 
             let choices = self.platform.get_platform_profile_choices()?;
-            if !choices.contains(&policy) {
-                return Err(FdoErr::NotSupported(format!(
-                    "RogPlatform: platform_profile: {} not supported",
-                    policy
-                )));
-            }
+            // Different ASUS platforms expose only one of Quiet / LowPower
+            // via the kernel ACPI platform_profile sysfs for the same
+            // semantic profile. Map the requested variant to the available
+            // one so user-facing setters succeed regardless of which name
+            // the kernel reports on this machine. Same bidirectional
+            // fallback is applied in set_platform_profile_on_battery /
+            // set_platform_profile_on_ac and at apply-time in
+            // select_power_profile_for_source.
+            let policy = if !choices.contains(&policy) {
+                match policy {
+                    PlatformProfile::Quiet
+                        if choices.contains(&PlatformProfile::LowPower) =>
+                    {
+                        PlatformProfile::LowPower
+                    }
+                    PlatformProfile::LowPower
+                        if choices.contains(&PlatformProfile::Quiet) =>
+                    {
+                        PlatformProfile::Quiet
+                    }
+                    _ => {
+                        return Err(FdoErr::NotSupported(format!(
+                            "RogPlatform: platform_profile: {} not supported",
+                            policy
+                        )));
+                    }
+                }
+            } else {
+                policy
+            };
 
             self.platform
                 .set_platform_profile(policy.into())
@@ -580,13 +611,22 @@ impl CtrlPlatform {
         #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
         policy: PlatformProfile,
     ) -> Result<(), FdoErr> {
-        // If the requested profile isn't available on this platform, and it's
-        // `Quiet`, fall back to `LowPower` so we don't write an unavailable
-        // profile into the config file.
+        // If the requested profile isn't available on this platform, fall
+        // back to the semantic equivalent (Quiet <-> LowPower) so we don't
+        // write an unavailable profile into the config file. Different ASUS
+        // platforms expose one or the other for the same semantic profile.
         let mut chosen = policy;
         if let Ok(choices) = self.platform.get_platform_profile_choices() {
-            if chosen == PlatformProfile::Quiet && !choices.contains(&PlatformProfile::Quiet) {
-                chosen = PlatformProfile::LowPower;
+            if !choices.contains(&chosen) {
+                if chosen == PlatformProfile::Quiet
+                    && choices.contains(&PlatformProfile::LowPower)
+                {
+                    chosen = PlatformProfile::LowPower;
+                } else if chosen == PlatformProfile::LowPower
+                    && choices.contains(&PlatformProfile::Quiet)
+                {
+                    chosen = PlatformProfile::Quiet;
+                }
             }
         }
 
@@ -619,11 +659,19 @@ impl CtrlPlatform {
         #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
         policy: PlatformProfile,
     ) -> Result<(), FdoErr> {
-        // Mirror the same fallback behavior for AC profile changes.
+        // Mirror the same bidirectional Quiet <-> LowPower fallback for AC.
         let mut chosen = policy;
         if let Ok(choices) = self.platform.get_platform_profile_choices() {
-            if chosen == PlatformProfile::Quiet && !choices.contains(&PlatformProfile::Quiet) {
-                chosen = PlatformProfile::LowPower;
+            if !choices.contains(&chosen) {
+                if chosen == PlatformProfile::Quiet
+                    && choices.contains(&PlatformProfile::LowPower)
+                {
+                    chosen = PlatformProfile::LowPower;
+                } else if chosen == PlatformProfile::LowPower
+                    && choices.contains(&PlatformProfile::Quiet)
+                {
+                    chosen = PlatformProfile::Quiet;
+                }
             }
         }
 

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -280,33 +280,22 @@ impl CtrlPlatform {
             self.config.lock().await.platform_profile_on_battery
         };
 
-        // Configs may contain a profile name (Quiet or LowPower) that this
-        // platform does not expose via the kernel ACPI sysfs — different ASUS
-        // platforms expose one or the other for the same semantic profile.
         // Normalize at apply-time so AC/BAT transitions still work correctly.
-        let alias = match configured {
-            PlatformProfile::Quiet => Some(PlatformProfile::LowPower),
-            PlatformProfile::LowPower => Some(PlatformProfile::Quiet),
-            _ => None,
-        };
-        if let Some(target) = alias {
-            if let Ok(choices) = self.platform.get_platform_profile_choices() {
-                if !choices.contains(&configured) && choices.contains(&target) {
-                    let mut cfg = self.config.lock().await;
-                    if power_plugged {
-                        cfg.platform_profile_on_ac = target;
-                    } else {
-                        cfg.platform_profile_on_battery = target;
-                    }
-                    cfg.write();
-                    warn!(
-                        "Configured profile {:?} is unavailable, falling back to {:?} for {}",
-                        configured,
-                        target,
-                        if power_plugged { "AC" } else { "battery" }
-                    );
-                    return target;
+        if let Ok(choices) = self.platform.get_platform_profile_choices() {
+            let target = configured.resolve_alias(&choices);
+            if target != configured {
+                let mut cfg = self.config.lock().await;
+                if power_plugged {
+                    cfg.platform_profile_on_ac = target;
+                } else {
+                    cfg.platform_profile_on_battery = target;
                 }
+                cfg.write();
+                warn!(
+                    "Rewrote stored {} profile {configured:?} as {target:?}",
+                    if power_plugged { "AC" } else { "battery" }
+                );
+                return target;
             }
         }
 
@@ -542,36 +531,13 @@ impl CtrlPlatform {
             self.config.lock().await.write();
 
             let choices = self.platform.get_platform_profile_choices()?;
-            // Different ASUS platforms expose only one of Quiet / LowPower
-            // via the kernel ACPI platform_profile sysfs for the same
-            // semantic profile. Map the requested variant to the available
-            // one so user-facing setters succeed regardless of which name
-            // the kernel reports on this machine. Same bidirectional
-            // fallback is applied in set_platform_profile_on_battery /
-            // set_platform_profile_on_ac and at apply-time in
-            // select_power_profile_for_source.
-            let policy = if !choices.contains(&policy) {
-                match policy {
-                    PlatformProfile::Quiet
-                        if choices.contains(&PlatformProfile::LowPower) =>
-                    {
-                        PlatformProfile::LowPower
-                    }
-                    PlatformProfile::LowPower
-                        if choices.contains(&PlatformProfile::Quiet) =>
-                    {
-                        PlatformProfile::Quiet
-                    }
-                    _ => {
-                        return Err(FdoErr::NotSupported(format!(
-                            "RogPlatform: platform_profile: {} not supported",
-                            policy
-                        )));
-                    }
-                }
-            } else {
-                policy
-            };
+            let policy = policy.resolve_alias(&choices);
+            if !choices.contains(&policy) {
+                return Err(FdoErr::NotSupported(format!(
+                    "RogPlatform: platform_profile: {} not supported",
+                    policy
+                )));
+            }
 
             self.platform
                 .set_platform_profile(policy.into())
@@ -611,23 +577,10 @@ impl CtrlPlatform {
         #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
         policy: PlatformProfile,
     ) -> Result<(), FdoErr> {
-        // If the requested profile isn't available on this platform, fall
-        // back to the semantic equivalent (Quiet <-> LowPower) so we don't
-        // write an unavailable profile into the config file. Different ASUS
-        // platforms expose one or the other for the same semantic profile.
+        // Store the name the kernel actually exposes, not the one asked for.
         let mut chosen = policy;
         if let Ok(choices) = self.platform.get_platform_profile_choices() {
-            if !choices.contains(&chosen) {
-                if chosen == PlatformProfile::Quiet
-                    && choices.contains(&PlatformProfile::LowPower)
-                {
-                    chosen = PlatformProfile::LowPower;
-                } else if chosen == PlatformProfile::LowPower
-                    && choices.contains(&PlatformProfile::Quiet)
-                {
-                    chosen = PlatformProfile::Quiet;
-                }
-            }
+            chosen = chosen.resolve_alias(&choices);
         }
 
         self.config.lock().await.platform_profile_on_battery = chosen;
@@ -659,20 +612,10 @@ impl CtrlPlatform {
         #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
         policy: PlatformProfile,
     ) -> Result<(), FdoErr> {
-        // Mirror the same bidirectional Quiet <-> LowPower fallback for AC.
+        // Mirror the same alias resolution for AC.
         let mut chosen = policy;
         if let Ok(choices) = self.platform.get_platform_profile_choices() {
-            if !choices.contains(&chosen) {
-                if chosen == PlatformProfile::Quiet
-                    && choices.contains(&PlatformProfile::LowPower)
-                {
-                    chosen = PlatformProfile::LowPower;
-                } else if chosen == PlatformProfile::LowPower
-                    && choices.contains(&PlatformProfile::Quiet)
-                {
-                    chosen = PlatformProfile::Quiet;
-                }
-            }
+            chosen = chosen.resolve_alias(&choices);
         }
 
         self.config.lock().await.platform_profile_on_ac = chosen;

--- a/rog-control-center/src/ui/setup_fans.rs
+++ b/rog-control-center/src/ui/setup_fans.rs
@@ -153,11 +153,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
 
         // TODO: the fan curve stuff was written donkeys ago with the expectation that
         // only 3 profiles existed
-        let profile = if platform_profile_choices.contains(&PlatformProfile::Quiet) {
-            PlatformProfile::Quiet
-        } else {
-            PlatformProfile::LowPower
-        };
+        let profile = PlatformProfile::Quiet.resolve_alias(&platform_profile_choices);
         let quiet = match fans.fan_curve_data(profile).await {
             Ok(data) => data,
             Err(e) => {
@@ -179,12 +175,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
                 let handle_next = handle_next1.clone();
                 let choices = choices.clone();
                 tokio::spawn(async move {
-                    let mut target: PlatformProfile = profile.into();
-                    if target == PlatformProfile::Quiet
-                        && !choices.contains(&PlatformProfile::Quiet)
-                    {
-                        target = PlatformProfile::LowPower;
-                    }
+                    let target = PlatformProfile::from(profile).resolve_alias(&choices);
                     if fans.set_curves_to_defaults(target).await.is_err() {
                         return;
                     }
@@ -203,7 +194,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
                         return;
                     };
                     let Ok(quiet) = fans
-                        .fan_curve_data(PlatformProfile::Quiet)
+                        .fan_curve_data(PlatformProfile::Quiet.resolve_alias(&choices))
                         .await
                         .map_err(|e| error!("{e:}"))
                     else {

--- a/rog-platform/src/platform.rs
+++ b/rog-platform/src/platform.rs
@@ -167,6 +167,26 @@ impl PlatformProfile {
             Self::Quiet | Self::LowPower | Self::Custom => Self::Balanced,
         }
     }
+
+    /// `Quiet` and `LowPower` are the same semantic profile; which name the
+    /// kernel exposes depends on the registered platform_profile handlers.
+    /// Substitute the equivalent name when the requested one is unavailable.
+    pub fn resolve_alias(self, choices: &[Self]) -> Self {
+        if choices.contains(&self) {
+            return self;
+        }
+        let alias = match self {
+            Self::Quiet => Self::LowPower,
+            Self::LowPower => Self::Quiet,
+            _ => return self,
+        };
+        if choices.contains(&alias) {
+            info!("Profile {self} is not exposed by the kernel, using {alias} instead");
+            alias
+        } else {
+            self
+        }
+    }
 }
 
 impl From<i32> for PlatformProfile {
@@ -301,4 +321,74 @@ pub fn get_fan_rpms() -> (i32, i32, i32) {
         }
     }
     (cpu, gpu, mid)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::platform::PlatformProfile;
+
+    // asus-wmi only ever exposes these
+    const ASUS_WMI: &[PlatformProfile] = &[
+        PlatformProfile::Quiet,
+        PlatformProfile::Balanced,
+        PlatformProfile::Performance,
+    ];
+    // amd-pmf exposes low-power instead, with quiet as a hidden choice
+    const AMD_PMF: &[PlatformProfile] = &[
+        PlatformProfile::LowPower,
+        PlatformProfile::Balanced,
+        PlatformProfile::Performance,
+    ];
+
+    #[test]
+    fn alias_substitutes_when_name_is_absent() {
+        assert_eq!(
+            PlatformProfile::LowPower.resolve_alias(ASUS_WMI),
+            PlatformProfile::Quiet
+        );
+        assert_eq!(
+            PlatformProfile::Quiet.resolve_alias(AMD_PMF),
+            PlatformProfile::LowPower
+        );
+    }
+
+    #[test]
+    fn alias_is_a_no_op_when_name_is_available() {
+        assert_eq!(
+            PlatformProfile::Quiet.resolve_alias(ASUS_WMI),
+            PlatformProfile::Quiet
+        );
+        assert_eq!(
+            PlatformProfile::LowPower.resolve_alias(AMD_PMF),
+            PlatformProfile::LowPower
+        );
+        for profile in [
+            PlatformProfile::Balanced,
+            PlatformProfile::Performance,
+        ] {
+            assert_eq!(profile.resolve_alias(ASUS_WMI), profile);
+            assert_eq!(profile.resolve_alias(AMD_PMF), profile);
+        }
+    }
+
+    #[test]
+    fn alias_does_not_invent_an_unavailable_profile() {
+        // Custom has no equivalent, and neither variant is available here
+        assert_eq!(
+            PlatformProfile::Custom.resolve_alias(ASUS_WMI),
+            PlatformProfile::Custom
+        );
+        let no_quiet = [
+            PlatformProfile::Balanced,
+            PlatformProfile::Performance,
+        ];
+        assert_eq!(
+            PlatformProfile::Quiet.resolve_alias(&no_quiet),
+            PlatformProfile::Quiet
+        );
+        assert_eq!(
+            PlatformProfile::LowPower.resolve_alias(&no_quiet),
+            PlatformProfile::LowPower
+        );
+    }
 }


### PR DESCRIPTION
## Summary

On hardware where the kernel ACPI platform_profile sysfs exposes only one of `Quiet` / `LowPower` for the same semantic profile (different ASUS DMI quirks expose different names — e.g. GA503QR exposes `quiet balanced performance`, never `low-power`), setting the absent variant fails with:

```
org.freedesktop.DBus.Error.NotSupported:
RogPlatform: platform_profile: (low-power) not supported
```

even when the equivalent IS in choices. The existing fallback in `set_platform_profile_on_battery` / `set_platform_profile_on_ac` only handled `Quiet -> LowPower`, and the bare `set_platform_profile` D-Bus property had no fallback at all.

This PR makes the alias bidirectional everywhere it matters:

- `set_platform_profile` (asusd/src/ctrl_platform.rs:469) — substitutes `Quiet <-> LowPower` when the requested variant isn't in `platform_profile_choices` but its semantic equivalent is.
- `set_platform_profile_on_battery` (~line 523) and `set_platform_profile_on_ac` (~line 562) — extended from one-direction to bidirectional, so the **canonical** name (the one the kernel exposes) is what gets persisted to `/etc/asusd/asusd.ron`.
- `select_power_profile_for_source` (~line 260) — extended to normalize both directions at apply-time, fixing stale-config rehydration after reboot or AC/BAT transitions.

## Background — relation to #648

The CLI-string-parsing portion of [GitLab issue #648](https://gitlab.com/asus-linux/asusctl/-/issues/648) was fixed by [GitLab MR !226](https://gitlab.com/asus-linux/asusctl/-/merge_requests/226) (commit `9366b0e`) which made `low-power` / `lowpower` / `LowPower` / `low_power` all parse to `PlatformProfile::LowPower`. That fix is necessary but not sufficient: the parsed enum then reaches `set_platform_profile`, which checks `choices.contains(&policy)` and rejects on hardware exposing only the kernel-renamed sibling name. This PR closes that follow-up gap.

## EPP / behavior preservation

EPP outcomes are unchanged. Both `Quiet` and `LowPower` already map to the same source in:
- `get_config_epp_for_throttle` (`asusd/src/ctrl_platform.rs:254-255`) — both → `profile_quiet_epp`
- `impl From<PlatformProfile> for CPUEPP` (`rog-platform/src/cpu.rs:209-210`) — both → `CPUEPP::Power`

So substitution does not affect what EPP gets written; only what name is stored in config and which sysfs string the kernel sees.

## Test plan — executed locally on patched daemon

Tested live on GA503QR (linux-g14 7.0.5, `/sys/firmware/acpi/platform_profile_choices = quiet balanced performance`) via a swap-in-place patched daemon (`systemctl stop asusd; systemd-run /target/release/asusd`):

| # | Command | Pre-patch | Post-patch | Result |
|---|---------|-----------|------------|--------|
| 1 | `asusctl profile set LowPower` | `NotSupported (low-power)` | kernel=`quiet`, active=`Quiet` | ✅ FIX |
| 2 | `asusctl profile set Quiet` | works | works | ✅ no regression |
| 3 | `asusctl profile set Balanced` | works | works | ✅ no regression |
| 4 | `asusctl profile set Performance` | works | works | ✅ no regression |
| 5 | `asusctl profile set NotARealProfile` | CLI parser rejects | CLI parser rejects | ✅ no regression |
| 6 | `asusctl profile set LowPower -b` | broken / wrong config | config persists `Quiet` (canonical), applied | ✅ FIX |
| 7 | `asusctl profile set LowPower -a` | broken / wrong config | config persists `Quiet` (canonical), applied | ✅ FIX |

Config persistence verified — `/etc/asusd/asusd.ron` after `set LowPower -b -a`:
```
platform_profile_on_battery: Quiet,
platform_profile_on_ac: Quiet,
```
(both stored as `Quiet`, the available canonical name, not `LowPower`).

`cargo check -p asusd` and `cargo build --release -p asusd` both clean on `ogc/main` tip.

## What we did NOT validate locally

This hardware exposes `quiet balanced performance` only — never `low-power`. So the reverse direction of the bidirectional fallback (a user passing `Quiet` on a hypothetical `low-power`-only machine) was reasoned-through (matches the existing one-direction precedent) but not hardware-tested. The patch is a strict no-op when the requested profile IS in choices, so on dual-choice or LowPower-only hardware the behavior should be unchanged from before this PR.

## Reviewer notes

- Pre-existing behavior left untouched: `set_platform_profile` writes config (line 480 in main) before validating against `choices`. The alias substitution doesn't widen that pre-existing window — the substitution only triggers when the validation would otherwise reject. Worth a separate cleanup PR if desired.
- No tests exist under `#[cfg(test)]` for `set_platform_profile` or the alias paths (verified via `rg`). Happy to add unit tests in a follow-up if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)