### PR TITLE
fix(asus-shutdown): exit cleanly on SIGTERM

### DIFF
--- a/asus-shutdown/src/main.rs
+++ b/asus-shutdown/src/main.rs
@@ -96,8 +96,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         tokio::select! {
             _ = sigterm.recv() => {
-                warn!("Received SIGTERM");
-                warn!("Deferring exit until deferred shutdown apply reaches a safe completion point");
+                warn!("Received SIGTERM, exiting cleanly");
+                break;
             }
             event = shutdown_events.next() => {
                 match event {


### PR DESCRIPTION
When asus-shutdown receives a SIGTERM outside of system shutdown (e.g. during manual service management or package update restarts), it ignored the signal and looped indefinitely waiting for logind's PrepareForShutdown signal. Combined with SendSIGKILL=no in the systemd service file, this caused commands like systemctl stop/restart asus-shutdown to hang indefinitely.

This patch makes asus-shutdown break the select loop and exit cleanly upon receiving SIGTERM. Since settings application is run synchronously within the event branch, SIGTERM will not interrupt an ongoing GPU firmware write.

Closes: https://github.com/OpenGamingCollective/asusctl/issues/140
Signed-off-by: Marco Scardovi <scardracs@disroot.org>