### PR TITLE
fix(asusd): skip failing armoury attributes instead of aborting

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -600,7 +600,7 @@ pub async fn start_attributes_zbus(
                 "Skipping attribute '{}' due to reload error: {e:?}",
                 attr.attr.name()
             );
-            break;
+            continue;
         }
 
         let attr_name = attr.attribute_name();


### PR DESCRIPTION
In start_attributes_zbus, if reload() fails for an attribute, the code logged that it was skipping it, but used break instead of continue. This aborted the entire registration of all subsequent attributes in the directory loop.

This patch changes the break to a continue, making individual attribute failures non-fatal, as originally intended.

Closes: https://github.com/OpenGamingCollective/asusctl/issues/132
Signed-off-by: Marco Scardovi <scardracs@disroot.org>