### PR TITLE
fix: sync Intel WMI CPU power limits to RAPL powercap interfaces dynamically

### DIFF
--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -240,9 +240,14 @@ impl Attribute {
                 if let Ok(int) = val.parse::<i32>() {
                     AttrValue::Integer(int)
                 } else if val.contains(';') {
-                    AttrValue::EnumInt(val.split(';').filter_map(|s| s.parse().ok()).collect())
+                    let values: Vec<_> = val.split(';').collect();
+                    if values.iter().all(|v| v.parse::<i32>().is_ok()) {
+                        AttrValue::EnumInt(values.iter().map(|v| v.parse().unwrap()).collect())
+                    } else {
+                        AttrValue::EnumStr(values.iter().map(|s| s.to_string()).collect())
+                    }
                 } else {
-                    AttrValue::EnumStr(val.split(';').map(|s| s.to_string()).collect())
+                    AttrValue::EnumStr(vec![val])
                 }
             }
             Err(_) => AttrValue::None,

--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -53,6 +53,70 @@ pub struct Attribute {
     base_path: PathBuf,
 }
 
+fn is_intel_cpu() -> bool {
+    std::fs::read_to_string("/proc/cpuinfo")
+        .map(|content| content.contains("GenuineIntel"))
+        .unwrap_or(false)
+}
+
+fn write_intel_rapl_limit(constraint_name: &str, watts: i32) {
+    if !is_intel_cpu() || watts < 0 {
+        return;
+    }
+    let microwatts_str = ((watts as u64) * 1_000_000).to_string();
+    let Ok(entries) = read_dir("/sys/class/powercap") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let zone_path = entry.path();
+        let zone = entry.file_name();
+        let zone = zone.to_string_lossy();
+        // A package zone name has exactly one ':' ("intel-rapl:0"). Sub-zones have two ("intel-rapl:0:0").
+        let is_package_zone = (zone.starts_with("intel-rapl:")
+            || zone.starts_with("intel-rapl-mmio:"))
+            && zone.matches(':').count() == 1;
+        if !is_package_zone {
+            continue;
+        }
+        let Ok(sub_entries) = read_dir(&zone_path) else {
+            continue;
+        };
+        for sub_entry in sub_entries.flatten() {
+            let file_name = sub_entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if file_name.starts_with("constraint_") && file_name.ends_with("_name") {
+                let name_path = sub_entry.path();
+                if let Ok(name) = std::fs::read_to_string(&name_path) {
+                    if name.trim() == constraint_name {
+                        let idx_str =
+                            &file_name["constraint_".len()..file_name.len() - "_name".len()];
+                        let limit_path =
+                            zone_path.join(format!("constraint_{}_power_limit_uw", idx_str));
+                        if limit_path.exists() {
+                            debug!("Writing {microwatts_str} to {}", limit_path.display());
+                            match OpenOptions::new().write(true).open(&limit_path) {
+                                Ok(mut file) => {
+                                    if let Err(e) = file.write_all(microwatts_str.as_bytes()) {
+                                        error!(
+                                            "Failed to write to {}: {}",
+                                            limit_path.display(),
+                                            e
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    error!("Failed to open {}: {}", limit_path.display(), e);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl Attribute {
     pub fn name(&self) -> &str {
         &self.name
@@ -97,6 +161,20 @@ impl Attribute {
 
         let mut file = OpenOptions::new().write(true).open(&path)?;
         file.write_all(value_str.as_bytes())?;
+
+        let constraint_name = match self.name.as_str() {
+            "ppt_pl1_spl" => Some("long_term"),
+            "ppt_pl2_sppt" => Some("short_term"),
+            "ppt_pl3_fppt" => Some("peak_power"),
+            _ => None,
+        };
+
+        if let Some(c_name) = constraint_name {
+            if let Ok(watts) = value_str.parse::<i32>() {
+                write_intel_rapl_limit(c_name, watts);
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Sync Intel CPU power limits (`ppt_pl1_spl`, `ppt_pl2_sppt`, `ppt_pl3_fppt`) to the kernel's RAPL (`powercap`) sysfs interfaces.
On modern Intel-based ROG laptops (such as the i9-13980HX on Strix G814JZ), the ASUS BIOS/WMI firmware does not correctly propagate or synchronize WMI power limits to the actual CPU MSR or MMIO RAPL registers. Writing to the WMI attributes under `asus-armoury` succeeds and reads back correctly, but has no actual hardware effect because the kernel's `intel-rapl-mmio` controller remains hard-locked at default constraint wattages (e.g., 45W/90W).
This patch bridges the gap by writing directly to the corresponding `/sys/class/powercap` nodes when Intel limits are set.
## Changes
1. **Intel CPU Detection**: Adds a safe `/proc/cpuinfo` check (`GenuineIntel`) to ensure this logic is only applied on Intel platforms.
2. **RAPL / Powercap Sync**: Walks `/sys/class/powercap` to find any directories belonging to package zones (e.g. `intel-rapl:*` / `intel-rapl-mmio:*`) and dynamically resolves the correct constraint index suffix by scanning and matching `constraint_<idx>_name` against the target name:
   - `"long_term"` for PL1 (`ppt_pl1_spl`)
   - `"short_term"` for PL2 (`ppt_pl2_sppt`)
   - `"peak_power"` for PL3 (`ppt_pl3_fppt`)
3. **Inline Syncing**: Rather than performing a full re-read and sync of all three limits every time, writes are executed dynamically and inline to the single updated attribute's corresponding RAPL constraint when it is modified.
## How to Test
Apply any CPU power limits via `asusctl`:
```bash
asusctl armoury set ppt_pl1_spl 110
asusctl armoury set ppt_pl2_sppt 135
```