### PR TITLE
fix(asusd): apply PPT limits on set even without ppt_enabled attribute

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -368,21 +368,11 @@ impl AsusArmouryAttribute {
     #[zbus(property)]
     async fn current_value(&self) -> fdo::Result<i32> {
         if self.name().property_type() == FirmwareAttributeType::Ppt {
-            let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
-            let power_plugged = self
-                .power
-                .get_online()
-                .map_err(|e| {
-                    error!("Could not get power status: {e:?}");
-                    e
-                })
-                .unwrap_or_default()
-                == 1;
-            let config = self.config.lock().await;
-            if let Some(tuning) = config.select_tunings_ref(power_plugged, profile) {
-                if let Some(tune) = tuning.group.get(&self.name()) {
-                    return Ok(*tune);
-                }
+            // Fix: report the real hardware value read from sysfs, not the cached
+            // per-profile config value. Returning the config value made tools show
+            // a PPT limit that may never have been written to the firmware.
+            if let Ok(AttrValue::Integer(i)) = self.attr.current_value() {
+                return Ok(i);
             }
             if let AttrValue::Integer(i) = self.attr.default_value() {
                 return Ok(*i);
@@ -443,6 +433,15 @@ impl AsusArmouryAttribute {
                 } else {
                     tuning.group.insert(self.name(), value);
                     debug!("Store tuning config for {name} = {:?}", value);
+                }
+
+                // Fix: an explicit user set implies intent to apply. On kernels
+                // without a `ppt_enabled` firmware attribute there is no other
+                // path to flip this per-profile flag, so enabling it here avoids
+                // silently discarding the write while the getter reports success.
+                if !tuning.enabled {
+                    info!("Auto-enabling PPT tuning for this profile on explicit set");
+                    tuning.enabled = true;
                 }
 
                 match tuning.enabled {


### PR DESCRIPTION
## What

Fixes PPT (`ppt_pl1_spl` / `ppt_pl2_sppt`) writes being silently discarded on kernels without a `ppt_enabled` firmware attribute. Fixes #149.

## Why

`set_current_value` gates PPT sysfs writes on the per-profile `Tuning.enabled` flag, but nothing sets that flag to `true` when the `ppt_enabled` attribute is absent (it is never registered because the sysfs node does not exist). Result: tuning can never be enabled, PPT writes are always skipped, and the `current_value` getter returns the cached config value — so `get` / the GUI report success while the hardware limit is unchanged.

## Changes (`asusd/src/asus_armoury.rs`)

- **`set_current_value` (Ppt):** auto-enable the profile's tuning group on an explicit set, so the value is actually written to hardware. This is the only sensible enable path when `ppt_enabled` is unavailable.
- **`current_value` (Ppt):** read the real value from sysfs instead of the cached config value, so tools report the true state.

## Testing

On G634JZ (i9-13980HX), kernel 7.1.2, asus-armoury **without** `ppt_enabled`:

- Before: `asusctl armoury set ppt_pl1_spl 65` → sysfs stays `140`.
- After: same command → `ppt_pl1_spl/current_value` == `65`; switching profiles now applies per-profile PPT (Quiet 65/95, Balanced 100/120, Performance 140/175), verified by reading the sysfs node directly.
- `cargo build --release -p asusd` clean.

## Open question

Auto-enabling on an explicit set slightly changes semantics for setups where `ppt_enabled` *does* exist (there the GUI toggle stays authoritative and can still disable afterward). Happy to gate this behind "only when no `ppt_enabled` attribute is present" if you prefer a more conservative fix.
