### PR TITLE
Add Lightbar power zone for G531G (ROG Strix G531)

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -285,7 +285,7 @@
         basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Pulse],
         basic_zones: [Key1, Key2, Key3, Key4],
         advanced_type: r#None,
-        power_zones: [Keyboard],
+        power_zones: [Keyboard, Lightbar],
     ),
     (
         device_name: "G531GW",


### PR DESCRIPTION
### What this does
The `G531G` entry in `rog-aura/data/aura_support.ron` only lists `power_zones: [Keyboard]`, so asusd never powers the laptop's light bar (the LED strip around the base). On Windows it lights up; on Linux it stays dark. This adds `Lightbar` so the strip is driven together with the keyboard.

### Hardware
- ROG Strix G531 series, tested on **G531GT** (i7-9750H + GTX 1650).
- asusd matches this laptop to the `G531G` profile (`Matched to G531G` in the log).

### Why this value
The `G512L` entry is identical to `G531G` in every relevant field except that it already enables the light bar:

```
device_name: "G512L",
basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Pulse],
basic_zones: [Key1, Key2, Key3, Key4],
advanced_type: None,
power_zones: [Keyboard, Lightbar],   // G531G was missing Lightbar
```

The G531 has the same class of light bar, so the same value applies.

### Behaviour after the change
- The light bar lights and follows the keyboard colour/effect (mirrors it).
- asusd represents the combined unit as a single `KeyboardAndLightbar` power zone, which matches the hardware — the strip is not independently addressable.
- `advanced_type` is left as `None` on purpose: the board does not support per-zone addressing. `asusctl aura effect static -c <hex> --zone 1` changes only the keyboard and switches the light bar off, so a `Zoned([...])` type would be incorrect here.

### Testing
1. Set `power_zones: [Keyboard, Lightbar]` for `G531G`.
2. `sudo systemctl restart asusd`.
3. `asusctl aura effect static -c ff0000` → keyboard and light bar both light red.
4. Colour/effect changes apply to both together, as expected for a mirrored, non-addressable strip.

### Scope
- Data-only change to `aura_support.ron`; no code, no new build dependencies.
- No interface/env-var/parameter change → no README update needed.
- `G531GW` (next entry) likely needs the same one-line change, but I could not test that variant, so it is left out of this PR.
