### PR TITLE
Add aura support for ASUS ROG Zephyrus M GU502GU

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -936,6 +936,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "GU502GU",
+        product_id: "",
+        layout_name: "gx502",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Star, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash],
+        basic_zones: [],
+        advanced_type: PerKey,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "GU603H",
         product_id: "",
         layout_name: "ga401q",


### PR DESCRIPTION
## Summary
- Adds an `aura_support.ron` entry for the ASUS ROG Zephyrus M **GU502GU**, which was previously missing (only `GU502L` existed).
- Confirmed on real hardware: this laptop has a per-key addressable RGB keyboard. Before this change, Aura only exposed Static color with no other effects/modes.
- Uses the same configuration as the existing `GU502L` entry (`layout_name: gx502`, `advanced_type: PerKey`, full effect list), which matches this model's actual capability and has been tested working (all effect modes functional, not just Static).

## Test plan
- [x] Built asusd + rog-control-center from this branch
- [x] Confirmed in `asusd` logs: `Matched to GU502GU`, keyboard LED config created for all 12 effect modes
- [x] Verified Aura effects (Static, Breathe, RainbowCycle, RainbowWave, Stars, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash) apply correctly on the physical per-key keyboard