### PR TITLE
feat: add FX507VU aura support

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -108,6 +108,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "FX507VU",
+        product_id: "",
+        layout_name: "fa507",
+        basic_modes: [Static, Breathe, RainbowCycle, Pulse],
+        basic_zones: [],
+        advanced_type: r#None,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "FX507VV",
         product_id: "",
         layout_name: "fa506i",


### PR DESCRIPTION
Add support for ASUS TUF F15 laptop keyboard lighting.
All modes were tested on my hardware for compatibility.