### PR TITLE
fan curves: don't factory-reset via pwmN_enable=3 when reading defaults (fixes asusd start hang + input freeze on TUF FX608JMR)

### DIFF
--- a/rog-profiles/src/lib.rs
+++ b/rog-profiles/src/lib.rs
@@ -157,13 +157,11 @@ impl FanCurveProfiles {
         profile: PlatformProfile,
         device: &mut Device,
     ) -> Result<(), ProfileError> {
-        let fans = Self::supported_fans()?;
-        // Do reset for all
-        for fan in fans {
-            let pwm_num: char = fan.into();
-            let pwm = format!("pwm{pwm_num}_enable");
-            device.set_attribute_value(&pwm, "3")?;
-        }
+        // Writing "3" to pwm<N>_enable makes the kernel re-fetch factory
+        // defaults via the fan_curve_get_factory_default WMI call. On some
+        // boards (TUF FX608JMR, BIOS 306) that call blocks ~30s, stalls the EC
+        // (input freezes) and returns EIO, so read the curves the driver
+        // already reports instead of resetting first.
         self.read_from_dev_profile(profile, device)?;
         Ok(())
     }


### PR DESCRIPTION
## Problem

On the 2025 TUF F16 (FX608JMR, BIOS 306, kernel 6.12), `asusd` never finishes its first start on a machine with no existing `fan_curves.ron`. It hangs right after fan discovery while fetching default fan curves, systemd kills it at the start timeout, `Restart=on-failure` loops it — and the machine's input (mouse cursor) freezes repeatedly while this happens.

```
asusd[28547]: [INFO  asusd::ctrl_fancurves] Fetching default fan curves
asusd[28547]: [DEBUG rog_profiles] Looking for pwm1_enable
asusd[28547]: [DEBUG rog_profiles] Found pwm1_enable
asusd[28547]: [DEBUG rog_profiles] Looking for pwm2_enable
asusd[28547]: [DEBUG rog_profiles] Found pwm2_enable
asusd[28547]: [DEBUG rog_profiles] Looking for pwm3_enable
systemd[1]: asusd.service: start operation timed out. Terminating.
```

## Root cause

`FanCurveProfiles::set_active_curve_to_defaults()` writes `"3"` to `pwmN_enable`, which makes the kernel re-fetch factory defaults via the `fan_curve_get_factory_default` WMI call. On this board that call blocks ~30 seconds, stalls the EC (that's the input freeze), and returns EIO. The kernel logs one of these per asusd start attempt, ~30s after the start:

```
kernel: asus_wmi: fan_curve_get_factory_default (0x00110024) failed: -5
```

Reads are unaffected — all `pwmN_enable` and `pwmN_auto_pointM_*` attributes read instantly with correct values from the driver's probe-time cache. Only the reset write triggers the blocked WMI call.

## Fix

Read the curves the driver already reports instead of forcing a firmware re-fetch first. On first run these are the factory defaults anyway. This also protects the D-Bus reset path from wedging the EC.

If dropping the reset globally is undesirable for models where the re-fetch works, I'm happy to rework this as a DMI-based quirk instead. There is likely also a kernel-side/firmware issue here (`fan_curve_get_factory_default` blocking 30s and stalling the EC), which asusd was only exposing.

## Testing

On the affected FX608JMR:

- asusd starts in ~1s (was: timeout loop + input freezes)
- per-profile default curves are read correctly for balanced/performance/quiet
- no `asus_wmi` errors in the kernel log
- fan curve writes (`asusctl fan-curve`) still work

Unrelated confirmation while I was testing: the `FX608JM` entry in `aura_support.ron` on `main` is correct for this machine — Static, Breathe, RainbowCycle, Pulse all verified working (single-zone, colours honoured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NneBinAM7WAFrqBqXZhA9
