### PR TITLE
fix(systemd): allow asus-shutdown to unload NVIDIA kernel modules (resolves #184)

### DIFF
--- a/data/asus-shutdown.service
+++ b/data/asus-shutdown.service
@@ -42,7 +42,7 @@ ProtectClock=true
 ProtectControlGroups=strict
 ProtectHostname=true
 ProtectKernelLogs=true
-ProtectKernelModules=true
+ProtectKernelModules=false
 ProtectKernelTunables=true
 
 RestrictAddressFamilies=AF_UNIX


### PR DESCRIPTION
## Problem & Symptoms
Switching between Integrated and Hybrid GPU modes followed by a reboot results in the brightness control becoming completely non-functional. In some instances, the reboot process hangs entirely and requires a forced physical power-off.

## Root Cause
To safely apply deferred GPU configurations to the motherboard's firmware during shutdown/reboot, the system must unload the active graphics driver stack. The `asus-shutdown` daemon implements `prepare_nvidia_for_gpu_firmware_writes()` which runs `modprobe -r` to unload all NVIDIA-related kernel modules (`nvidia_drm`, `nvidia_modeset`, `nvidia_uvm`, `nvidia`) and prevent conflicts.
However, the systemd service file [data/asus-shutdown.service](https://github.com/OpenGamingCollective/asusctl/blob/main/data/asus-shutdown.service) was configured with:
```ini
ProtectKernelModules=true
```
Causing the modprobe -r to fail

## Proposed fix
Simply changing `ProtectKernelModules=true` to `ProtectKernelModules=false`

Fixes: https://github.com/OpenGamingCollective/asusctl/issues/184