### PR TITLE
feat: add FA608WI aura support

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -45,6 +45,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "FA608WI",
+        product_id: "",
+        layout_name: "fa608",
+        basic_modes: [Static, Breathe, RainbowCycle, Pulse],
+        basic_zones: [],
+        advanced_type: r#None,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "FA608UH",
         product_id: "",
         layout_name: "fa608",


### PR DESCRIPTION
aura_support.ron entry for FA608PM is the same for FA608WI.