### PR TITLE
refactor: replace external sg git dependency & centralize workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ nvml-wrapper = "^0.12.0"
 pix = "^0.13"
 png = "^0.17"
 png_pong = "^0.8"
-ron = "*"
+ron = "^0.12.2"
 rusb = "^0.9"
 sdl2 = { version = "^0.37", default-features = false }
 serde = { version = "^1.0", features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,37 @@ members = [
 default-members = ["asusctl", "asusd", "asus-shutdown", "asusd-user", "rog-control-center"]
 
 [workspace.dependencies]
+argh = "^0.1"
+ashpd = { version = "^0.13", default-features = false, features = ["async-io", "global_shortcuts"] }
+concat-idents = "^1.1"
+console-subscriber = "^0.4"
+dirs = "^4.0"
+env_logger = "^0.10.0"
+futures-util = "^0.3.31"
+gif = "^0.12"
+glam = { version = "^0.22", features = ["serde"] }
+gumdrop = "^0.8"
+image = "^0.25.5"
+inotify = "^0.10"
+ksni = { version = "^0.3", default-features = false, features = ["async-io"] }
+libc = "^0.2"
+log = "^0.4"
+logind-zbus = { version = "^5.2.0" }
+mio = "^0.8.11"
+nix = { version = "^0.29", features = ["uio"] }
+notify-rust = { version = "^4.11.5", features = ["z", "async"] }
+nvml-wrapper = "^0.12.0"
+pix = "^0.13"
+png = "^0.17"
+png_pong = "^0.8"
+ron = "*"
+rusb = "^0.9"
+sdl2 = { version = "^0.37", default-features = false }
+serde = { version = "^1.0", features = ["serde_derive"] }
+serde_json = "^1.0"
+slint = { version = "^1.17.1", features = ["gettext"] }
+slint-build = "^1.17.1"
+thiserror = "^2"
 tokio = { version = "^1.39.0", default-features = false, features = [
   "macros",
   "sync",
@@ -42,46 +73,9 @@ tokio = { version = "^1.39.0", default-features = false, features = [
   "rt",
   "rt-multi-thread",
 ] }
-concat-idents = "^1.1"
-dirs = "^4.0"
-mio = "^0.8.11"
-
-futures-util = "^0.3.31"
-zbus = "^5.13.1"
-logind-zbus = { version = "^5.2.0" }
-
-serde = { version = "^1.0", features = ["serde_derive"] }
-serde_json = "^1.0"
-ron = "*"
-
-log = "^0.4"
-env_logger = "^0.10.0"
-thiserror = "^2"
-
-glam = { version = "^0.22", features = ["serde"] }
-gumdrop = "^0.8"
 udev = { version = "^0.8", features = ["mio"] }
-rusb = "^0.9"
-inotify = "^0.10"
-
-png_pong = "^0.8"
-pix = "^0.13"
-gif = "^0.12"
-
-notify-rust = { version = "^4.11.5", features = ["z", "async"] }
-ksni = { version = "^0.3", default-features = false, features = ["async-io"] }
-image = "^0.25.5"
-png = "^0.17"
-slint = { version = "^1.17.1", features = ["gettext"] }
-slint-build = "^1.17.1"
-argh = "^0.1"
 uhid-virt = "^0.0.8"
-sdl2 = { version = "^0.37", default-features = false }
-libc = "^0.2"
-nix = { version = "^0.29", features = ["uio"] }
-nvml-wrapper = "^0.12.0"
-ashpd = { version = "^0.13", default-features = false, features = ["async-io", "global_shortcuts"] }
-console-subscriber = "^0.4"
+zbus = "^5.13.1"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,11 @@ slint-build = "^1.17.1"
 argh = "^0.1"
 uhid-virt = "^0.0.8"
 sdl2 = { version = "^0.37", default-features = false }
+libc = "^0.2"
+nix = { version = "^0.29", features = ["uio"] }
+nvml-wrapper = "^0.12.0"
+ashpd = { version = "^0.13", default-features = false, features = ["async-io", "global_shortcuts"] }
+console-subscriber = "^0.4"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,6 @@ argh = "^0.1"
 uhid-virt = "^0.0.8"
 sdl2 = { version = "^0.37", default-features = false }
 
-sg = { git = "https://github.com/flukejones/sg-rs.git" }
-
 [profile.release]
 lto = "thin"
 debug = false

--- a/rog-aura/Cargo.toml
+++ b/rog-aura/Cargo.toml
@@ -23,5 +23,5 @@ dmi_id = { path = "../dmi-id" }
 # cli and logging
 log.workspace = true
 
-ron = { version = "*", optional = true }
+ron = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/rog-control-center/Cargo.toml
+++ b/rog-control-center/Cargo.toml
@@ -17,11 +17,11 @@ tokio-debug = ["console-subscriber"]
 rog_ally = []
 
 [dependencies]
-console-subscriber = { version = "^0.4", optional = true }
+console-subscriber = { workspace = true, optional = true }
 
-ksni = { version = "0.3", default-features = false, features = ["async-io"] }
-image = "0.25.5"
-ashpd = { version = "0.13", default-features = false, features = ["async-io", "global_shortcuts"] }
+ksni.workspace = true
+image.workspace = true
+ashpd.workspace = true
 
 asusd = { path = "../asusd" }
 config-traits = { path = "../config-traits" }
@@ -46,8 +46,8 @@ concat-idents.workspace = true
 futures-util.workspace = true
 thiserror.workspace = true
 udev.workspace = true
-serde_json = "1.0"
-nvml-wrapper = "0.12.0"
+serde_json.workspace = true
+nvml-wrapper.workspace = true
 
 [dependencies.slint]
 git = "https://github.com/slint-ui/slint.git"

--- a/rog-platform/Cargo.toml
+++ b/rog-platform/Cargo.toml
@@ -17,7 +17,7 @@ udev.workspace = true
 inotify.workspace = true
 rusb.workspace = true
 thiserror.workspace = true
-nvml-wrapper = "0.12.0"
+nvml-wrapper.workspace = true
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/rog-scsi/Cargo.toml
+++ b/rog-scsi/Cargo.toml
@@ -15,7 +15,8 @@ default = ["dbus", "ron"]
 dbus = ["zbus"]
 
 [dependencies]
-sg.workspace = true
+libc = "^0.2"
+nix = { version = "^0.29", features = ["uio"] }
 serde.workspace = true
 zbus = { workspace = true, optional = true }
 

--- a/rog-scsi/Cargo.toml
+++ b/rog-scsi/Cargo.toml
@@ -15,12 +15,12 @@ default = ["dbus", "ron"]
 dbus = ["zbus"]
 
 [dependencies]
-libc = "^0.2"
-nix = { version = "^0.29", features = ["uio"] }
+libc.workspace = true
+nix.workspace = true
 serde.workspace = true
 zbus = { workspace = true, optional = true }
 
 # cli and logging
 
-ron = { version = "*", optional = true }
+ron = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/rog-scsi/src/builtin_modes.rs
+++ b/rog-scsi/src/builtin_modes.rs
@@ -7,6 +7,7 @@ use zbus::zvariant::{OwnedValue, Type, Value};
 
 use crate::error::Error;
 use crate::scsi::{apply_task, dir_task, mode_task, rgb_task, save_task, speed_task};
+use crate::sg::Task;
 
 #[cfg_attr(feature = "dbus", derive(Type, Value, OwnedValue))]
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Deserialize, Serialize)]
@@ -366,7 +367,7 @@ impl Display for AuraEffect {
     }
 }
 
-impl From<&AuraEffect> for Vec<sg::Task> {
+impl From<&AuraEffect> for Vec<Task> {
     fn from(effect: &AuraEffect) -> Self {
         let mut tasks = Vec::new();
 

--- a/rog-scsi/src/lib.rs
+++ b/rog-scsi/src/lib.rs
@@ -1,6 +1,7 @@
 mod builtin_modes;
 mod error;
 mod scsi;
+pub mod sg;
 
 pub use builtin_modes::*;
 pub use error::*;

--- a/rog-scsi/src/scsi.rs
+++ b/rog-scsi/src/scsi.rs
@@ -1,6 +1,4 @@
-extern crate sg;
-
-pub use sg::Task;
+use crate::sg::{Direction, Task};
 
 static ENE_APPLY_VAL: u8 = 0x01; // Value for Apply Changes Register
 static ENE_SAVE_VAL: u8 = 0xaa;
@@ -37,7 +35,7 @@ fn data(reg: u32, arg_count: u8) -> [u8; 16] {
 pub(crate) fn rgb_task(led: u32, rgb: &[u8; 3]) -> Task {
     let mut task = Task::new();
     task.set_cdb(data(led * 3 + ENE_REG_COLORS_EFFECT_V2, 3).as_slice());
-    task.set_data(rgb, sg::Direction::ToDevice);
+    task.set_data(rgb, Direction::ToDevice);
     task
 }
 
@@ -45,7 +43,7 @@ pub(crate) fn rgb_task(led: u32, rgb: &[u8; 3]) -> Task {
 pub(crate) fn mode_task(mode: u8) -> Task {
     let mut task = Task::new();
     task.set_cdb(data(ENE_REG_MODE, 1).as_slice());
-    task.set_data(&[mode.min(13)], sg::Direction::ToDevice);
+    task.set_data(&[mode.min(13)], Direction::ToDevice);
     task
 }
 
@@ -53,7 +51,7 @@ pub(crate) fn mode_task(mode: u8) -> Task {
 pub(crate) fn speed_task(speed: u8) -> Task {
     let mut task = Task::new();
     task.set_cdb(data(ENE_REG_SPEED, 1).as_slice());
-    task.set_data(&[speed.min(4)], sg::Direction::ToDevice);
+    task.set_data(&[speed.min(4)], Direction::ToDevice);
     task
 }
 
@@ -61,20 +59,20 @@ pub(crate) fn speed_task(speed: u8) -> Task {
 pub(crate) fn dir_task(mode: u8) -> Task {
     let mut task = Task::new();
     task.set_cdb(data(ENE_REG_DIRECTION, 1).as_slice());
-    task.set_data(&[mode.min(1)], sg::Direction::ToDevice);
+    task.set_data(&[mode.min(1)], Direction::ToDevice);
     task
 }
 
 pub(crate) fn apply_task() -> Task {
     let mut task = Task::new();
     task.set_cdb(data(ENE_REG_APPLY, 1).as_slice());
-    task.set_data(&[ENE_APPLY_VAL], sg::Direction::ToDevice);
+    task.set_data(&[ENE_APPLY_VAL], Direction::ToDevice);
     task
 }
 
 pub(crate) fn save_task() -> Task {
     let mut task = Task::new();
     task.set_cdb(data(ENE_REG_APPLY, 1).as_slice());
-    task.set_data(&[ENE_SAVE_VAL], sg::Direction::ToDevice);
+    task.set_data(&[ENE_SAVE_VAL], Direction::ToDevice);
     task
 }

--- a/rog-scsi/src/sg.rs
+++ b/rog-scsi/src/sg.rs
@@ -1,0 +1,339 @@
+use std::ffi::c_void;
+use std::fs::{File, OpenOptions};
+use std::io::{self, IoSlice, IoSliceMut};
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::Path;
+use std::time::Duration;
+
+pub const SG_DXFER_NONE: i32 = -1;
+pub const SG_DXFER_TO_DEV: i32 = -2;
+pub const SG_DXFER_FROM_DEV: i32 = -3;
+pub const SG_DXFER_TO_FROM_DEV: i32 = -4;
+
+pub const SG_INFO_OK_MASK: u32 = 0x1;
+pub const SG_INFO_OK: u32 = 0x0;
+pub const SG_MAX_QUEUE: usize = 16;
+pub const SG_IO: u64 = 0x2285;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SgIoHdr {
+    pub interface_id: std::os::raw::c_int,
+    pub dxfer_direction: std::os::raw::c_int,
+    pub cmd_len: u8,
+    pub mx_sb_len: u8,
+    pub iovec_count: u16,
+    pub dxfer_len: u32,
+    pub dxferp: *mut c_void,
+    pub cmdp: *mut u8,
+    pub sbp: *mut u8,
+    pub timeout: u32,
+    pub flags: u32,
+    pub pack_id: std::os::raw::c_int,
+    pub usr_ptr: *mut c_void,
+    pub status: u8,
+    pub masked_status: u8,
+    pub msg_status: u8,
+    pub sb_len_wr: u8,
+    pub host_status: u16,
+    pub driver_status: u16,
+    pub resid: i32,
+    pub duration: u32,
+    pub info: u32,
+}
+
+impl Default for SgIoHdr {
+    fn default() -> Self {
+        Self {
+            interface_id: b'S' as std::os::raw::c_int,
+            dxfer_direction: SG_DXFER_NONE,
+            cmd_len: 0,
+            mx_sb_len: 0,
+            iovec_count: 0,
+            dxfer_len: 0,
+            dxferp: std::ptr::null_mut(),
+            cmdp: std::ptr::null_mut(),
+            sbp: std::ptr::null_mut(),
+            timeout: 0,
+            flags: 0,
+            pack_id: 0,
+            usr_ptr: std::ptr::null_mut(),
+            status: 0,
+            masked_status: 0,
+            msg_status: 0,
+            sb_len_wr: 0,
+            host_status: 0,
+            driver_status: 0,
+            resid: 0,
+            duration: 0,
+            info: 0,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Direction {
+    None,
+    ToDevice,
+    FromDevice,
+    ToFromDevice,
+}
+
+impl Direction {
+    fn to_underlying(self) -> std::os::raw::c_int {
+        match self {
+            Direction::None => SG_DXFER_NONE,
+            Direction::ToDevice => SG_DXFER_TO_DEV,
+            Direction::FromDevice => SG_DXFER_FROM_DEV,
+            Direction::ToFromDevice => SG_DXFER_TO_FROM_DEV,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Task {
+    inner: SgIoHdr,
+    cmd: Vec<u8>,
+    data: Vec<u8>,
+    sense: Vec<u8>,
+}
+
+impl Default for Task {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: Task manages its internal buffers and SgIoHdr raw pointers. The raw pointers
+// are updated prior to any ioctl execution to point directly to owned heap vectors, making
+// Send and Sync safe across thread boundaries.
+unsafe impl Send for Task {}
+unsafe impl Sync for Task {}
+
+impl Task {
+    pub fn new() -> Self {
+        Task {
+            inner: SgIoHdr::default(),
+            cmd: Vec::new(),
+            data: Vec::new(),
+            sense: Vec::new(),
+        }
+    }
+
+    /// Prepares raw internal pointers in SgIoHdr to match current buffer memory addresses.
+    pub fn sync_pointers(&mut self) {
+        if !self.cmd.is_empty() {
+            self.inner.cmdp = self.cmd.as_mut_ptr();
+            self.inner.cmd_len = self.cmd.len() as u8;
+        } else {
+            self.inner.cmdp = std::ptr::null_mut();
+            self.inner.cmd_len = 0;
+        }
+
+        if !self.data.is_empty() {
+            self.inner.dxferp = self.data.as_mut_ptr() as *mut c_void;
+            self.inner.dxfer_len = self.data.len() as u32;
+        } else {
+            self.inner.dxferp = std::ptr::null_mut();
+            self.inner.dxfer_len = 0;
+        }
+
+        if !self.sense.is_empty() {
+            self.inner.sbp = self.sense.as_mut_ptr();
+            self.inner.mx_sb_len = self.sense.len() as u8;
+        } else {
+            self.inner.sbp = std::ptr::null_mut();
+            self.inner.mx_sb_len = 0;
+        }
+    }
+
+    pub fn set_cdb(&mut self, buf: &[u8]) -> &mut Self {
+        self.cmd = buf.to_vec();
+        self.sync_pointers();
+        self
+    }
+
+    pub fn cdb(&self) -> &[u8] {
+        &self.cmd
+    }
+
+    pub fn set_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.inner.timeout = timeout.as_millis() as u32;
+        self
+    }
+
+    pub fn timeout(&self) -> Duration {
+        Duration::from_millis(u64::from(self.inner.timeout))
+    }
+
+    pub fn set_data(&mut self, buf: &[u8], direction: Direction) -> &mut Self {
+        self.data = buf.to_vec();
+        self.inner.dxfer_direction = direction.to_underlying();
+        self.sync_pointers();
+        self
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+
+    pub fn set_sense_buffer(&mut self, buf: &[u8]) -> &mut Self {
+        self.sense = buf.to_vec();
+        self.sync_pointers();
+        self
+    }
+
+    pub fn sense_buffer(&self) -> &[u8] {
+        &self.sense
+    }
+
+    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
+        self.inner.flags = flags;
+        self
+    }
+
+    pub fn flags(&self) -> u32 {
+        self.inner.flags
+    }
+
+    pub fn duration(&self) -> u32 {
+        self.inner.duration
+    }
+
+    pub fn residual_data(&self) -> i32 {
+        self.inner.resid
+    }
+
+    pub fn status(&self) -> u8 {
+        self.inner.status
+    }
+
+    pub fn host_status(&self) -> u16 {
+        self.inner.host_status
+    }
+
+    pub fn driver_status(&self) -> u16 {
+        self.inner.driver_status
+    }
+
+    pub fn ok(&self) -> bool {
+        (self.inner.info & SG_INFO_OK_MASK) == SG_INFO_OK
+    }
+}
+
+pub struct Device(File);
+
+impl Device {
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Device> {
+        Ok(Device(
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(path)?,
+        ))
+    }
+
+    /// Sends multiple tasks to the SCSI device queue.
+    pub fn send(&self, tasks: &mut [Task]) -> io::Result<usize> {
+        if tasks.is_empty() {
+            return Ok(0);
+        }
+
+        for task in tasks.iter_mut() {
+            task.sync_pointers();
+        }
+
+        // SAFETY: SgIoHdr is a repr(C) struct with standard byte layout. We create a read-only
+        // slice over the byte buffer of each SgIoHdr for writev.
+        let iovecs: Vec<IoSlice> = tasks
+            .iter()
+            .map(|task| {
+                IoSlice::new(unsafe {
+                    std::slice::from_raw_parts(
+                        &task.inner as *const SgIoHdr as *const u8,
+                        std::mem::size_of::<SgIoHdr>(),
+                    )
+                })
+            })
+            .collect();
+
+        loop {
+            match nix::sys::uio::writev(&self.0, &iovecs[..tasks.len()]) {
+                Ok(n) => break Ok(n / std::mem::size_of::<SgIoHdr>()),
+                Err(nix::errno::Errno::EINTR) => {}
+                Err(e) => break Err(e.into()),
+            }
+        }
+    }
+
+    /// Receives completed tasks from the SCSI device queue.
+    pub fn receive(&self, tasks: &mut Vec<Task>) -> io::Result<usize> {
+        let mut hdrs = [SgIoHdr::default(); SG_MAX_QUEUE];
+
+        // SAFETY: SgIoHdr is a repr(C) struct. We create a mutable byte slice over each header
+        // buffer to allow readv to populate header data.
+        let mut iovecs: Vec<IoSliceMut> = hdrs
+            .iter_mut()
+            .map(|hdr| {
+                IoSliceMut::new(unsafe {
+                    std::slice::from_raw_parts_mut(
+                        hdr as *mut SgIoHdr as *mut u8,
+                        std::mem::size_of::<SgIoHdr>(),
+                    )
+                })
+            })
+            .collect();
+
+        let bytes_read = loop {
+            match nix::sys::uio::readv(&self.0, iovecs.as_mut_slice()) {
+                Ok(n) => break n,
+                Err(e) if e == nix::errno::Errno::EINTR || e == nix::errno::Errno::EAGAIN => {}
+                Err(e) => return Err(e.into()),
+            }
+        };
+
+        if bytes_read == 0 {
+            return Ok(0);
+        }
+
+        let tasks_read = bytes_read / std::mem::size_of::<SgIoHdr>();
+        for hdr in hdrs.iter().take(tasks_read) {
+            let mut task = Task::new();
+            task.inner = *hdr;
+            tasks.push(task);
+        }
+        Ok(tasks_read)
+    }
+
+    /// Performs a synchronous SCSI IO operation via ioctl.
+    pub fn perform(&self, task: &Task) -> io::Result<()> {
+        let mut task_copy = task.clone();
+        task_copy.sync_pointers();
+
+        #[cfg(target_env = "musl")]
+        let request = SG_IO as i32;
+        #[cfg(not(target_env = "musl"))]
+        let request: u64 = SG_IO;
+
+        // SAFETY: The raw file descriptor is open and valid, and task_copy has valid synced
+        // buffer pointers matching the initialized memory of task_copy.inner.
+        let ret = unsafe { libc::ioctl(self.0.as_raw_fd(), request, &task_copy.inner) };
+        if ret == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl AsRawFd for Device {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}


### PR DESCRIPTION
## Summary

This PR removes the external git dependency `sg = { git = "https://github.com/flukejones/sg-rs.git" }` by introducing an in-tree native Linux SCSI Generic implementation inside `rog-scsi`. Additionally, it centralizes all external crate dependencies under `[workspace.dependencies]` in the root `Cargo.toml` and sorts them alphabetically.

---

## Key Changes

### 1. In-Tree Linux SCSI Generic Implementation (`rog-scsi`)
* Added `rog-scsi/src/sg.rs`: Native, safe Rust implementation of Linux SCSI Generic (`sg_io_hdr`, `SG_IO` ioctl, `Task`, `Device`, `Direction`).
* Updated `rog-scsi/src/scsi.rs` and `rog-scsi/src/builtin_modes.rs` to use the in-tree `sg` module.
* All `unsafe` blocks include mandatory `// SAFETY:` invariant documentation, with zero `.unwrap()` calls.

### 2. Workspace Dependencies Centralization & Cleanup
* **Root `Cargo.toml`**:
  * Centralized all direct external crate dependencies under `[workspace.dependencies]` (`libc`, `nix`, `nvml-wrapper`, `ashpd`, `console-subscriber`).
  * Replaced wildcard `ron = "*"` with pinned version `ron = "^0.12.2"`.
  * Sorted all entries under `[workspace.dependencies]` in alphabetical order.
* **Subcrate `Cargo.toml` Files**:
  * Updated `rog-scsi/Cargo.toml`, `rog-platform/Cargo.toml`, `rog-control-center/Cargo.toml`, and `rog-aura/Cargo.toml` to inherit dependencies using `.workspace = true`.

---

## Verification
All workspace checks and tests pass cleanly with zero errors and zero warnings:
- [x] `cargo check --all-targets`
- [x] `cargo test --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo cranky`
- [x] `cargo fmt --all -- --check`