### PR TITLE
Fix: Pause Telemetry Loop When Window is Hidden

### DIFF
--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -236,7 +236,7 @@ async fn main() -> Result<()> {
             if is_rog_ally {
                 let config_copy_2 = config.clone();
                 let newui =
-                    setup_window(config.clone(), prefetched_supported.clone(), is_tuf, None);
+                    setup_window(config.clone(), prefetched_supported.clone(), app_state.clone(), is_tuf, None);
                 newui.window().on_close_requested(move || {
                     exit(0);
                 });

--- a/rog-control-center/src/ui/mod.rs
+++ b/rog-control-center/src/ui/mod.rs
@@ -18,6 +18,7 @@ use slint::{ComponentHandle, SharedString, Weak};
 
 use crate::config::Config;
 use crate::shortcuts::{EnableMode, ShortcutHandle, ShortcutStatus};
+use crate::zbus_proxies::AppState;
 use crate::ui::setup_anime::setup_anime_page;
 use crate::ui::setup_aura::setup_aura_page;
 use crate::ui::setup_fans::setup_fan_curve_page;
@@ -130,6 +131,7 @@ pub fn show_toast(
 pub fn setup_window(
     config: Arc<Mutex<Config>>,
     prefetched_supported: std::sync::Arc<Option<Vec<i32>>>,
+    app_state: Arc<Mutex<AppState>>,
     is_tuf: bool,
     shortcuts: Option<ShortcutHandle>,
 ) -> MainWindow {
@@ -168,7 +170,7 @@ pub fn setup_window(
 
     setup_app_settings_page(&ui, config.clone(), shortcuts);
     if available.contains(&"xyz.ljones.Platform".to_string()) {
-        setup_system_page(&ui, config.clone());
+        setup_system_page(&ui, config.clone(), app_state.clone());
         setup_system_page_callbacks(&ui, config.clone());
     }
     if available.contains(&"xyz.ljones.Aura".to_string()) {

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -11,7 +11,7 @@ use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use super::show_toast;
 use crate::config::Config;
-use crate::zbus_proxies::find_iface_async;
+use crate::zbus_proxies::{find_iface_async, AppState};
 use crate::{set_ui_callbacks, AttrMinMax, MainWindow, SystemPageData};
 
 const MINMAX: AttrMinMax = AttrMinMax {
@@ -20,7 +20,7 @@ const MINMAX: AttrMinMax = AttrMinMax {
     current: -1.0,
 };
 
-pub fn setup_system_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
+pub fn setup_system_page(ui: &MainWindow, _config: Arc<Mutex<Config>>, app_state: Arc<Mutex<AppState>>) {
     let conn = zbus::blocking::Connection::system()
         .map_err(|e| error!("DBus system connection failed: {e:?}"))
         .unwrap();
@@ -100,6 +100,15 @@ pub fn setup_system_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
     tokio::spawn(async move {
         let mut prev_ticks = rog_platform::cpu::read_cpu_ticks();
         loop {
+            let visible = app_state
+                .try_lock()
+                .map(|s| *s == AppState::MainWindowOpen)
+                .unwrap_or(false);
+            if !visible {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                continue;
+            }
+
             let power = rog_platform::power::AsusPower::new().ok();
             let (has_bat, health, consumption, status, estimate_str) = if let Some(ref p) = power {
                 if p.has_battery() {

--- a/rog-control-center/src/window.rs
+++ b/rog-control-center/src/window.rs
@@ -108,6 +108,7 @@ impl WindowController {
             let ui = setup_window(
                 self.0.config.clone(),
                 self.0.prefetched_supported.clone(),
+                self.0.app_state.clone(),
                 self.0.is_tuf,
                 self.0.shortcuts.get().cloned(),
             );


### PR DESCRIPTION
The telemetry loop continues to poll in the background even when the window is not visible, leading to unnecessary hold-up of the dGPU leading it to not go into power-saving (d3cold). 

I am taking Arc reference to the AppState and checking if the window is open, and skipping the iteration if the window is not.

There is 1 case where this will fail: if the window is visible but minimized to the "app bar" / taskbar, then polling still continues. Checking if the window is not minimized will require us to hook into Slint's visibility mechanic, and I did not feel that's required here.

Fixes #208 