### PR TITLE
refactor: replace gumdrop with argh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ env_logger = "^0.11.11"
 futures-util = "^0.3.33"
 gif = "^0.14.2"
 glam = { version = "^0.33.2", features = ["serde"] }
-gumdrop = "^0.8.1"
 image = "^0.25.10"
 inotify = "^0.11.4"
 ksni = { version = "^0.3.6", default-features = false, features = ["async-io"] }

--- a/rog-control-center/Cargo.toml
+++ b/rog-control-center/Cargo.toml
@@ -33,7 +33,7 @@ rog_platform = { path = "../rog-platform" }
 rog_slash = { path = "../rog-slash" }
 dmi_id = { path = "../dmi-id" }
 
-gumdrop.workspace = true
+argh.workspace = true
 log.workspace = true
 env_logger.workspace = true
 

--- a/rog-control-center/src/cli_options.rs
+++ b/rog-control-center/src/cli_options.rs
@@ -1,31 +1,33 @@
-use gumdrop::Options;
+use argh::FromArgs;
 
-#[derive(Default, Options)]
+#[derive(Default, FromArgs)]
+/// ROG Control Center
 pub struct CliStart {
-    #[options(help_flag, help = "print help message")]
-    pub help: bool,
-    #[options(help = "start fullscreen, if used the option is saved")]
+    /// start fullscreen, if used the option is saved
+    #[argh(switch)]
     pub fullscreen: bool,
-    #[options(help = "fullscreen width")]
+    /// fullscreen width
+    #[argh(option, default = "0")]
     pub width_fullscreen: u32,
-    #[options(help = "fullscreen height")]
+    /// fullscreen height
+    #[argh(option, default = "0")]
     pub height_fullscreen: u32,
-    #[options(help = "start windowed, if used the option is saved")]
+    /// start windowed, if used the option is saved
+    #[argh(switch)]
     pub windowed: bool,
-    #[options(help = "show program version number")]
+    /// show program version number
+    #[argh(switch)]
     pub version: bool,
-    #[options(help = "start in background (UI closed)")]
+    /// start in background (UI closed)
+    #[argh(switch)]
     pub background: bool,
-    #[options(help = "indicate that the app was launched via autostart")]
+    /// indicate that the app was launched via autostart
+    #[argh(switch)]
     pub autostart: bool,
-    #[options(
-        meta = "",
-        help = "set board name for testing, this will make ROGCC show only the keyboard page"
-    )]
+    /// set board name for testing, this will make ROGCC show only the keyboard page
+    #[argh(option)]
     pub board_name: Option<String>,
-    #[options(
-        help = "put ROGCC in layout viewing mode - this is helpful for finding existing layouts \
-                that might match your laptop"
-    )]
+    /// put ROGCC in layout viewing mode - this is helpful for finding existing layouts that might match your laptop
+    #[argh(switch)]
     pub layout_viewing: bool,
 }

--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -38,6 +38,13 @@ async fn main() -> Result<()> {
         .format_timestamp(None)
         .init();
 
+    let cli_parsed: CliStart = argh::from_env();
+
+    if cli_parsed.version {
+        print_versions();
+        return Ok(());
+    }
+
     // If we're running under gamescope we have to set WAYLAND_DISPLAY for winit to
     // use
     if let Ok(gamescope) = env::var("GAMESCOPE_WAYLAND_DISPLAY") {
@@ -109,13 +116,6 @@ async fn main() -> Result<()> {
     let board_name = dmi.board_name;
     let prod_family = dmi.product_family;
     info!("Running on {board_name}, product: {prod_family}");
-
-    let cli_parsed: CliStart = argh::from_env();
-
-    if cli_parsed.version {
-        print_versions();
-        return Ok(());
-    }
 
     let supported_properties = platform_proxy.supported_properties().unwrap_or_default();
 

--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -1,4 +1,4 @@
-use std::env::{self, args};
+use std::env;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::sync::{Arc, Mutex};
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use config_traits::{StdConfig, StdConfigLoad1};
 use dmi_id::DMIID;
-use gumdrop::Options;
 use log::{debug, error, info, warn, LevelFilter};
 use rog_control_center::cli_options::CliStart;
 use rog_control_center::config::Config;
@@ -111,17 +110,10 @@ async fn main() -> Result<()> {
     let prod_family = dmi.product_family;
     info!("Running on {board_name}, product: {prod_family}");
 
-    let args: Vec<String> = args().skip(1).collect();
+    let cli_parsed: CliStart = argh::from_env();
 
-    let cli_parsed = match CliStart::parse_args_default(&args) {
-        Ok(p) => p,
-        Err(err) => {
-            eprintln!("Error parsing command line arguments: {err}");
-            std::process::exit(1);
-        }
-    };
-
-    if do_cli_help(&cli_parsed) {
+    if cli_parsed.version {
+        print_versions();
         return Ok(());
     }
 
@@ -306,26 +298,6 @@ async fn main() -> Result<()> {
     }
     rt.shutdown_background();
     Ok(())
-}
-
-fn do_cli_help(parsed: &CliStart) -> bool {
-    if parsed.help {
-        println!("{}", CliStart::usage());
-        println!();
-        if let Some(cmdlist) = CliStart::command_list() {
-            let commands: Vec<String> = cmdlist.lines().map(|s| s.to_owned()).collect();
-            for command in &commands {
-                println!("{}", command);
-            }
-        }
-    }
-
-    if parsed.version {
-        print_versions();
-        println!();
-    }
-
-    parsed.help
 }
 
 pub fn get_layout_path(path: &Path, layout_name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

Unifies CLI argument parsing across the workspace to use `argh` exclusively by migrating `rog-control-center` from `gumdrop` to `argh`, completely removing `gumdrop` and its transitive dependencies (`gumdrop_derive`, legacy `syn v1`).

## Motivation
`gumdrop` is an unmaintained crate flagged by dependency audit tools. `asusctl` CLI already uses `argh` as its parser. Unifying `rog-control-center` to `argh` eliminates dual CLI dependencies across workspace crates and reduces dependency count and maintenance overhead.

## Commits

1. **`refactor(rog-control-center): migrate CliStart parser from gumdrop to argh`**
   - Migrated `CliStart` struct in `cli_options.rs` from `gumdrop::Options` derive to `argh::FromArgs`.
   - Updated `main.rs` to use `argh::from_env()`, removing `do_cli_help` and unused imports.
   - Updated `rog-control-center/Cargo.toml` dependency from `gumdrop` to `argh`.

2. **`chore: remove gumdrop dependency from workspace`**
   - Removed `gumdrop` declaration from root `Cargo.toml` `[workspace.dependencies]`.

## Verification & Testing

- [x] Verified CLI options (`--fullscreen`, `--windowed`, `--background`, `--autostart`, `--version`, `--board-name`, `--layout-viewing`) parse accurately with `argh`.
- [x] `cargo audit` confirms 0 direct unmaintained dependencies (`gumdrop` eliminated).
- [x] `cargo check --all-targets` passed cleanly.
- [x] `cargo test --all` passed 100% of unit & integration tests.
- [x] `cargo clippy --all -- -D warnings` passed with 0 warnings.
- [x] `cargo cranky` passed with 0 warnings.
- [x] `cargo fmt --all -- --check` formatted cleanly.