### PR TITLE
fix(gui): adjust log levels for optional interfaces and multi-device detection

### DIFF
--- a/rog-control-center/src/ui/setup_gpu.rs
+++ b/rog-control-center/src/ui/setup_gpu.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use log::error;
+use log::{error, info};
 use rog_dbus::asus_armoury::AsusArmouryProxy;
 use rog_dbus::zbus_platform::PlatformProxy;
 use rog_dbus::zbus_xgm_led::XgmLedProxy;
@@ -293,7 +293,7 @@ pub fn setup_gpu_page(ui: &MainWindow) {
         // --- XG Mobile LED ---
         let xgm_results: Option<(XgmLedProxy<'static>, bool)> = async {
             let Ok(mut proxies) = find_iface_async::<XgmLedProxy>("xyz.ljones.XgmLed").await else {
-                error!("setup_gpu: no XG Mobile LED interface");
+                info!("setup_gpu: no XG Mobile LED interface");
                 return None;
             };
             let xgm_proxy = proxies.pop()?;

--- a/rog-control-center/src/zbus_proxies.rs
+++ b/rog-control-center/src/zbus_proxies.rs
@@ -1,3 +1,4 @@
+use log::info;
 use std::sync::{Arc, Mutex};
 
 use zbus::blocking::proxy::ProxyImpl;
@@ -109,7 +110,7 @@ where
         }
     }
     if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found");
+        info!("Multiple asusd interfaces devices found");
     }
     if !paths.is_empty() {
         let mut ctrl = Vec::new();
@@ -147,7 +148,7 @@ where
         }
     }
     if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found");
+        info!("Multiple asusd interfaces devices found");
     }
     if !paths.is_empty() {
         let mut ctrl = Vec::new();


### PR DESCRIPTION
## Summary
This Pull Request improves log hygiene in `rog-control-center` by downgrading misleading `error!` and `warn!` log messages to `info!` during standard application startup on ROG laptops.

### Problem & Rationale
1. **Missing XG Mobile LED Interface**: Most ROG laptops (e.g. ROG Strix, TUF, Zephyrus) do not have an XG Mobile external eGPU port. Attempting to query `xyz.ljones.XgmLed` on non-Flow models previously logged an `error!`, causing confusion and falsely suggesting system errors on laptops without XG Mobile hardware.
2. **Multiple `asusd` Device Detection**: ROG laptops with multi-zone RGB lighting (e.g. keyboard LEDs, front lightbar, lid logo) legitimately report multiple D-Bus object paths for the same interface (e.g. `org.asuslinux.Aura`). Querying `get_managed_objects()` when `paths.len() > 1` previously emitted a `log::warn!`, despite this being normal multi-device operation.

### Solution
1. **`rog-control-center/src/ui/setup_gpu.rs`**:
   - Imported `info` at top (`use log::{error, info};`).
   - Downgraded `error!("setup_gpu: no XG Mobile LED interface");` to `info!`.
2. **`rog-control-center/src/zbus_proxies.rs`**:
   - Imported `use log::info;` at top.
   - Downgraded `log::warn!("Multiple asusd interfaces devices found");` in `find_iface` and `find_iface_async` to `info!`.

---

## Detailed Changes
* **`rog-control-center/src/ui/setup_gpu.rs`**: Adjust missing XG Mobile LED interface log level.
* **`rog-control-center/src/zbus_proxies.rs`**: Adjust multi-device detection log level.

---

## Verification & Testing
- [x] **`cargo check --all-targets`**: Clean compilation across workspace crates.
- [x] **`cargo test --all`**: All unit tests passing.
- [x] **`cargo clippy --all -- -D warnings`**: 0 warnings.
- [x] **`cargo cranky`**: 0 warnings.
- [x] **`cargo fmt --all -- --check`**: Formatting verified.
- [x] **Git Hooks**: Pre-commit and pre-push hooks executed cleanly.