### PR TITLE
fix(asusd): improve async task supervision, eliminate unwrap panics, and deduplicate ZBus registration

### DIFF
--- a/asusd/src/aura_anime/trait_impls.rs
+++ b/asusd/src/aura_anime/trait_impls.rs
@@ -316,28 +316,18 @@ impl crate::CtrlTask for AniMeZbus {
         let inner2 = self.0.clone();
         let inner3 = self.0.clone();
         let inner4 = self.0.clone();
-        self.create_sys_event_tasks(
-            move |sleeping| {
-                // on_sleep
-                let inner = inner1.clone();
-                async move {
-                    let config = inner.config.lock().await.clone();
-                    if config.display_enabled {
-                        inner.thread_exit.store(true, Ordering::Release); // ensure clean slate
+        let mut tasks = self
+            .create_sys_event_tasks(
+                move |sleeping| {
+                    // on_sleep
+                    let inner = inner1.clone();
+                    async move {
+                        let config = inner.config.lock().await.clone();
+                        if config.display_enabled {
+                            inner.thread_exit.store(true, Ordering::Release); // ensure clean slate
 
-                        inner
-                            .write_bytes(&pkt_set_enable_display(
-                                !(sleeping && config.off_when_suspended),
-                            ))
-                            .await
-                            .map_err(|err| {
-                                warn!("create_sys_event_tasks::off_when_suspended {}", err);
-                            })
-                            .ok();
-
-                        if config.builtin_anims_enabled {
                             inner
-                                .write_bytes(&pkt_set_enable_powersave_anim(
+                                .write_bytes(&pkt_set_enable_display(
                                     !(sleeping && config.off_when_suspended),
                                 ))
                                 .await
@@ -345,105 +335,127 @@ impl crate::CtrlTask for AniMeZbus {
                                     warn!("create_sys_event_tasks::off_when_suspended {}", err);
                                 })
                                 .ok();
-                        } else if !sleeping && !config.builtin_anims_enabled {
-                            // Run custom wake animation
-                            inner
-                                .write_bytes(&pkt_set_enable_powersave_anim(false))
-                                .await
-                                .ok(); // ensure builtins are disabled
 
-                            inner.run_thread(inner.cache.wake.clone(), true).await;
+                            if config.builtin_anims_enabled {
+                                inner
+                                    .write_bytes(&pkt_set_enable_powersave_anim(
+                                        !(sleeping && config.off_when_suspended),
+                                    ))
+                                    .await
+                                    .map_err(|err| {
+                                        warn!("create_sys_event_tasks::off_when_suspended {}", err);
+                                    })
+                                    .ok();
+                            } else if !sleeping && !config.builtin_anims_enabled {
+                                // Run custom wake animation
+                                inner
+                                    .write_bytes(&pkt_set_enable_powersave_anim(false))
+                                    .await
+                                    .ok(); // ensure builtins are disabled
+
+                                inner.run_thread(inner.cache.wake.clone(), true).await;
+                            }
                         }
                     }
-                }
-            },
-            move |shutting_down| {
-                // on_shutdown
-                let inner = inner2.clone();
-                async move {
-                    let AniMeConfig {
-                        display_enabled,
-                        builtin_anims_enabled,
-                        ..
-                    } = *inner.config.lock().await;
-                    if display_enabled && !builtin_anims_enabled {
-                        if shutting_down {
-                            inner.run_thread(inner.cache.shutdown.clone(), true).await;
+                },
+                move |shutting_down| {
+                    // on_shutdown
+                    let inner = inner2.clone();
+                    async move {
+                        let AniMeConfig {
+                            display_enabled,
+                            builtin_anims_enabled,
+                            ..
+                        } = *inner.config.lock().await;
+                        if display_enabled && !builtin_anims_enabled {
+                            if shutting_down {
+                                inner.run_thread(inner.cache.shutdown.clone(), true).await;
+                            } else {
+                                inner.run_thread(inner.cache.boot.clone(), true).await;
+                            }
+                        }
+                    }
+                },
+                move |lid_closed| {
+                    let inner = inner3.clone();
+                    // on lid change
+                    async move {
+                        let AniMeConfig {
+                            off_when_lid_closed,
+                            builtin_anims_enabled,
+                            ..
+                        } = *inner.config.lock().await;
+                        if off_when_lid_closed {
+                            if builtin_anims_enabled {
+                                inner
+                                    .write_bytes(&pkt_set_enable_powersave_anim(!lid_closed))
+                                    .await
+                                    .map_err(|err| {
+                                        warn!(
+                                            "create_sys_event_tasks::off_when_lid_closed {}",
+                                            err
+                                        );
+                                    })
+                                    .ok();
+                            }
+                            inner
+                                .write_bytes(&pkt_set_enable_display(!lid_closed))
+                                .await
+                                .map_err(|err| {
+                                    warn!("create_sys_event_tasks::off_when_lid_closed {}", err);
+                                })
+                                .ok();
+                        }
+                    }
+                },
+                move |power_plugged| {
+                    let inner = inner4.clone();
+                    // on power change
+                    async move {
+                        let AniMeConfig {
+                            off_when_unplugged,
+                            builtin_anims_enabled,
+                            brightness_on_battery,
+                            ..
+                        } = *inner.config.lock().await;
+                        if off_when_unplugged {
+                            if builtin_anims_enabled {
+                                inner
+                                    .write_bytes(&pkt_set_enable_powersave_anim(power_plugged))
+                                    .await
+                                    .map_err(|err| {
+                                        warn!("create_sys_event_tasks::off_when_unplugged {}", err);
+                                    })
+                                    .ok();
+                            }
+                            inner
+                                .write_bytes(&pkt_set_enable_display(power_plugged))
+                                .await
+                                .map_err(|err| {
+                                    warn!("create_sys_event_tasks::off_when_unplugged {}", err);
+                                })
+                                .ok();
                         } else {
-                            inner.run_thread(inner.cache.boot.clone(), true).await;
-                        }
-                    }
-                }
-            },
-            move |lid_closed| {
-                let inner = inner3.clone();
-                // on lid change
-                async move {
-                    let AniMeConfig {
-                        off_when_lid_closed,
-                        builtin_anims_enabled,
-                        ..
-                    } = *inner.config.lock().await;
-                    if off_when_lid_closed {
-                        if builtin_anims_enabled {
                             inner
-                                .write_bytes(&pkt_set_enable_powersave_anim(!lid_closed))
+                                .write_bytes(&pkt_set_brightness(brightness_on_battery))
                                 .await
                                 .map_err(|err| {
-                                    warn!("create_sys_event_tasks::off_when_suspended {}", err);
+                                    warn!("create_sys_event_tasks::off_when_unplugged {}", err);
                                 })
                                 .ok();
                         }
-                        inner
-                            .write_bytes(&pkt_set_enable_display(!lid_closed))
-                            .await
-                            .map_err(|err| {
-                                warn!("create_sys_event_tasks::off_when_lid_closed {}", err);
-                            })
-                            .ok();
                     }
+                },
+            )
+            .await?;
+
+        tokio::spawn(async move {
+            while let Some(res) = tasks.join_next().await {
+                if let Err(err) = res {
+                    warn!("AniMeZbus background task ended with error: {err:?}");
                 }
-            },
-            move |power_plugged| {
-                let inner = inner4.clone();
-                // on power change
-                async move {
-                    let AniMeConfig {
-                        off_when_unplugged,
-                        builtin_anims_enabled,
-                        brightness_on_battery,
-                        ..
-                    } = *inner.config.lock().await;
-                    if off_when_unplugged {
-                        if builtin_anims_enabled {
-                            inner
-                                .write_bytes(&pkt_set_enable_powersave_anim(power_plugged))
-                                .await
-                                .map_err(|err| {
-                                    warn!("create_sys_event_tasks::off_when_suspended {}", err);
-                                })
-                                .ok();
-                        }
-                        inner
-                            .write_bytes(&pkt_set_enable_display(power_plugged))
-                            .await
-                            .map_err(|err| {
-                                warn!("create_sys_event_tasks::off_when_unplugged {}", err);
-                            })
-                            .ok();
-                    } else {
-                        inner
-                            .write_bytes(&pkt_set_brightness(brightness_on_battery))
-                            .await
-                            .map_err(|err| {
-                                warn!("create_sys_event_tasks::off_when_unplugged {}", err);
-                            })
-                            .ok();
-                    }
-                }
-            },
-        )
-        .await?;
+            }
+        });
 
         Ok(())
     }

--- a/asusd/src/aura_anime/trait_impls.rs
+++ b/asusd/src/aura_anime/trait_impls.rs
@@ -443,7 +443,7 @@ impl crate::CtrlTask for AniMeZbus {
                 }
             },
         )
-        .await;
+        .await?;
 
         Ok(())
     }

--- a/asusd/src/aura_anime/trait_impls.rs
+++ b/asusd/src/aura_anime/trait_impls.rs
@@ -316,7 +316,7 @@ impl crate::CtrlTask for AniMeZbus {
         let inner2 = self.0.clone();
         let inner3 = self.0.clone();
         let inner4 = self.0.clone();
-        let mut tasks = self
+        let tasks = self
             .create_sys_event_tasks(
                 move |sleeping| {
                     // on_sleep
@@ -449,13 +449,7 @@ impl crate::CtrlTask for AniMeZbus {
             )
             .await?;
 
-        tokio::spawn(async move {
-            while let Some(res) = tasks.join_next().await {
-                if let Err(err) = res {
-                    warn!("AniMeZbus background task ended with error: {err:?}");
-                }
-            }
-        });
+        Self::spawn_task_supervisor("AniMeZbus", tasks);
 
         Ok(())
     }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -271,8 +271,7 @@ impl CtrlTask for AuraZbus {
                         info!("CtrlKbdLedTask reloading brightness and modes");
                         let brightness = inner3.config.lock().await.brightness;
                         if let Some(backlight) = &inner3.backlight {
-                            if let Err(e) =
-                                backlight.lock().await.set_brightness(brightness.into())
+                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
                             {
                                 error!("CtrlKbdLedTask brightness error: {e}");
                             }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -241,7 +241,7 @@ impl CtrlTask for AuraZbus {
     async fn create_tasks(&self, _: SignalEmitter<'static>) -> Result<(), RogError> {
         let inner1 = self.0.clone();
         let inner3 = self.0.clone();
-        let mut tasks = self
+        let tasks = self
             .create_sys_event_tasks(
                 move |sleeping| {
                     let inner1 = inner1.clone();
@@ -290,40 +290,7 @@ impl CtrlTask for AuraZbus {
             )
             .await?;
 
-        tokio::spawn(async move {
-            while let Some(res) = tasks.join_next().await {
-                if let Err(err) = res {
-                    warn!("AuraZbus background task ended with error: {err:?}");
-                }
-<<<<<<< HEAD
-            },
-            move |_shutting_down| {
-                let inner3 = inner3.clone();
-                async move {
-                    info!("CtrlKbdLedTask reloading brightness and modes");
-                    let brightness = inner3.config.lock().await.brightness;
-                    if let Some(backlight) = &inner3.backlight {
-                        if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
-                        {
-                            error!("CtrlKbdLedTask brightness error: {e}");
-                        }
-                    }
-                }
-            },
-            move |_lid_closed| {
-                // on lid change
-                async move {}
-            },
-            move |_power_plugged| {
-                // power change
-                async move {}
-            },
-        )
-        .await?;
-=======
-            }
-        });
->>>>>>> 71c10a4b (refactor(asusd): update task watch macros and create_sys_event_tasks to return JoinSet and JoinHandle)
+        Self::spawn_task_supervisor("AuraZbus", tasks);
 
         Ok(())
     }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -241,46 +241,61 @@ impl CtrlTask for AuraZbus {
     async fn create_tasks(&self, _: SignalEmitter<'static>) -> Result<(), RogError> {
         let inner1 = self.0.clone();
         let inner3 = self.0.clone();
-        self.create_sys_event_tasks(
-            move |sleeping| {
-                let inner1 = inner1.clone();
-                async move {
-                    if !sleeping {
+        let mut tasks = self
+            .create_sys_event_tasks(
+                move |sleeping| {
+                    let inner1 = inner1.clone();
+                    async move {
+                        if !sleeping {
+                            info!("CtrlKbdLedTask reloading brightness and modes");
+                            let brightness = inner1.config.lock().await.brightness;
+                            if let Some(backlight) = &inner1.backlight {
+                                if let Err(e) =
+                                    backlight.lock().await.set_brightness(brightness.into())
+                                {
+                                    error!("CtrlKbdLedTask brightness error: {e}");
+                                }
+                            }
+                            let mut config = inner1.config.lock().await;
+                            if let Err(e) = inner1.write_current_config_mode(&mut config).await {
+                                error!("CtrlKbdLedTask config mode error: {e}");
+                            }
+                        } else if let Err(e) = inner1.update_config().await {
+                            error!("CtrlKbdLedTask update config error: {e}");
+                        }
+                    }
+                },
+                move |_shutting_down| {
+                    let inner3 = inner3.clone();
+                    async move {
                         info!("CtrlKbdLedTask reloading brightness and modes");
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                        let brightness = inner1.config.lock().await.brightness;
-                        if let Some(backlight) = &inner1.backlight {
+                        let brightness = inner3.config.lock().await.brightness;
+                        if let Some(backlight) = &inner3.backlight {
                             if let Err(e) =
                                 backlight.lock().await.set_brightness(brightness.into())
-=======
-                        let brightness = inner3.config.lock().await.brightness;
-                        if let Some(backlight) = &inner3.backlight {
-                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
->>>>>>> eaf1be57 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
-=======
-                        let brightness = inner3.config.lock().await.brightness;
-                        if let Some(backlight) = &inner3.backlight {
-                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
->>>>>>> 79c2ce24 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
-=======
-                        let brightness = inner3.config.lock().await.brightness;
-                        if let Some(backlight) = &inner3.backlight {
-                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
->>>>>>> db5143c8 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
                             {
                                 error!("CtrlKbdLedTask brightness error: {e}");
                             }
                         }
-                        let mut config = inner1.config.lock().await;
-                        if let Err(e) = inner1.write_current_config_mode(&mut config).await {
-                            error!("CtrlKbdLedTask config mode error: {e}");
-                        }
-                    } else if let Err(e) = inner1.update_config().await {
-                        error!("CtrlKbdLedTask update config error: {e}");
                     }
+                },
+                move |_lid_closed| {
+                    // on lid change
+                    async move {}
+                },
+                move |_power_plugged| {
+                    // power change
+                    async move {}
+                },
+            )
+            .await?;
+
+        tokio::spawn(async move {
+            while let Some(res) = tasks.join_next().await {
+                if let Err(err) = res {
+                    warn!("AuraZbus background task ended with error: {err:?}");
                 }
+<<<<<<< HEAD
             },
             move |_shutting_down| {
                 let inner3 = inner3.clone();
@@ -305,6 +320,10 @@ impl CtrlTask for AuraZbus {
             },
         )
         .await?;
+=======
+            }
+        });
+>>>>>>> 71c10a4b (refactor(asusd): update task watch macros and create_sys_event_tasks to return JoinSet and JoinHandle)
 
         Ok(())
     }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -39,8 +39,10 @@ impl AuraZbus {
             .object_server()
             .at(path.clone(), self)
             .await
-            .map_err(|e| error!("Couldn't add server at path: {path}, {e:?}"))
-            .ok();
+            .map_err(|e| {
+                error!("Couldn't add server at path: {path}, {e:?}");
+                e
+            })?;
         // TODO: skip this until we keep handles to tasks so they can be killed
         // task.create_tasks(signal_ctx).await
         Ok(())

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -242,39 +242,41 @@ impl CtrlTask for AuraZbus {
         self.create_sys_event_tasks(
             move |sleeping| {
                 let inner1 = inner1.clone();
-                // unwrap as we want to bomb out of the task
                 async move {
                     if !sleeping {
                         info!("CtrlKbdLedTask reloading brightness and modes");
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+                        let brightness = inner1.config.lock().await.brightness;
                         if let Some(backlight) = &inner1.backlight {
-                            backlight
-                                .lock()
-                                .await
-                                .set_brightness(inner1.config.lock().await.brightness.into())
-                                .map_err(|e| {
-                                    error!("CtrlKbdLedTask: {e}");
-                                    e
-                                })
-                                .unwrap();
+                            if let Err(e) =
+                                backlight.lock().await.set_brightness(brightness.into())
+=======
+                        let brightness = inner3.config.lock().await.brightness;
+                        if let Some(backlight) = &inner3.backlight {
+                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
+>>>>>>> eaf1be57 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
+=======
+                        let brightness = inner3.config.lock().await.brightness;
+                        if let Some(backlight) = &inner3.backlight {
+                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
+>>>>>>> 79c2ce24 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
+=======
+                        let brightness = inner3.config.lock().await.brightness;
+                        if let Some(backlight) = &inner3.backlight {
+                            if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
+>>>>>>> db5143c8 (fixup! fix(asusd): remove unwrap panics in CtrlKbdLedTask event handlers)
+                            {
+                                error!("CtrlKbdLedTask brightness error: {e}");
+                            }
                         }
                         let mut config = inner1.config.lock().await;
-                        inner1
-                            .write_current_config_mode(&mut config)
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
-                    } else if sleeping {
-                        inner1
-                            .update_config()
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                        if let Err(e) = inner1.write_current_config_mode(&mut config).await {
+                            error!("CtrlKbdLedTask config mode error: {e}");
+                        }
+                    } else if let Err(e) = inner1.update_config().await {
+                        error!("CtrlKbdLedTask update config error: {e}");
                     }
                 }
             },
@@ -282,17 +284,12 @@ impl CtrlTask for AuraZbus {
                 let inner3 = inner3.clone();
                 async move {
                     info!("CtrlKbdLedTask reloading brightness and modes");
+                    let brightness = inner3.config.lock().await.brightness;
                     if let Some(backlight) = &inner3.backlight {
-                        // unwrap as we want to bomb out of the task
-                        backlight
-                            .lock()
-                            .await
-                            .set_brightness(inner3.config.lock().await.brightness.into())
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                        if let Err(e) = backlight.lock().await.set_brightness(brightness.into())
+                        {
+                            error!("CtrlKbdLedTask brightness error: {e}");
+                        }
                     }
                 }
             },
@@ -305,28 +302,7 @@ impl CtrlTask for AuraZbus {
                 async move {}
             },
         )
-        .await;
-
-        // let ctrl2 = self.0.clone();
-        // let ctrl = self.0.lock().await;
-        // if ctrl.led_node.has_brightness_control() {
-        //     let watch = ctrl.led_node.monitor_brightness()?;
-        //     tokio::spawn(async move {
-        //         let mut buffer = [0; 32];
-        //         watch
-        //             .into_event_stream(&mut buffer)
-        //             .unwrap()
-        //             .for_each(|_| async {
-        //                 if let Some(lock) = ctrl2.try_lock() {
-        //                     load_save(true, lock).unwrap(); // unwrap as we want
-        //                                                     // to
-        //                                                     // bomb out of the
-        //                                                     // task
-        //                 }
-        //             })
-        //             .await;
-        //     });
-        // }
+        .await?;
 
         Ok(())
     }

--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -27,6 +27,26 @@ use crate::ASUS_ZBUS_PATH;
 
 const MOD_NAME: &str = "aura";
 
+fn register_device_zbus(
+    devices: &mut Vec<AsusDevice>,
+    dev_type: DeviceHandle,
+    path: OwnedObjectPath,
+    start_result: Result<(), RogError>,
+    dev_name: &str,
+    hid_key: Option<String>,
+) {
+    if start_result
+        .map_err(|e| error!("Failed to start {dev_name} tasks: {e:?}, not adding this device"))
+        .is_ok()
+    {
+        devices.push(AsusDevice {
+            device: dev_type,
+            dbus_path: path,
+            hid_key,
+        });
+    }
+}
+
 /// Returns only the Device details concatenated in a form usable for
 /// adding/appending to a filename
 pub fn filename_partial(parent: &Device) -> Option<OwnedObjectPath> {
@@ -153,21 +173,17 @@ impl DeviceManager {
                             if let DeviceHandle::Slash(slash) = dev_type.clone() {
                                 let path =
                                     dbus_path_for_dev(&usb_device).unwrap_or(dbus_path_for_slash());
-                                let ctrl = SlashZbus::new(slash);
-                                if ctrl
+                                let res = SlashZbus::new(slash)
                                     .start_tasks(connection, path.clone())
-                                    .await
-                                    .map_err(|e| {
-                                        error!("Failed to start Slash tasks: {e:?}, not adding this device")
-                                    })
-                                    .is_ok()
-                                {
-                                    devices.push(AsusDevice {
-                                        device: dev_type,
-                                        dbus_path: path,
-                                        hid_key: Some(hid_key.clone()),
-                                    });
-                                }
+                                    .await;
+                                register_device_zbus(
+                                    &mut devices,
+                                    dev_type,
+                                    path,
+                                    res,
+                                    "Slash",
+                                    Some(hid_key.clone()),
+                                );
                             }
                         }
                         // ANIME MATRIX DEVICE
@@ -180,21 +196,17 @@ impl DeviceManager {
                             if let DeviceHandle::AniMe(anime) = dev_type.clone() {
                                 let path =
                                     dbus_path_for_dev(&usb_device).unwrap_or(dbus_path_for_anime());
-                                let ctrl = AniMeZbus::new(anime);
-                                if ctrl
+                                let res = AniMeZbus::new(anime)
                                     .start_tasks(connection, path.clone())
-                                    .await
-                                    .map_err(|e| {
-                                        error!("Failed to start AniMe tasks: {e:?}, not adding this device")
-                                    })
-                                    .is_ok()
-                                {
-                                    devices.push(AsusDevice {
-                                        device: dev_type,
-                                        dbus_path: path,
-                                        hid_key: Some(hid_key.clone()),
-                                    });
-                                }
+                                    .await;
+                                register_device_zbus(
+                                    &mut devices,
+                                    dev_type,
+                                    path,
+                                    res,
+                                    "AniMe",
+                                    Some(hid_key.clone()),
+                                );
                             }
                         }
                         // AURA LAPTOP DEVICE
@@ -207,21 +219,17 @@ impl DeviceManager {
                             if let DeviceHandle::Aura(aura) = dev_type.clone() {
                                 let path =
                                     dbus_path_for_dev(&usb_device).unwrap_or(dbus_path_for_tuf());
-                                let ctrl = AuraZbus::new(aura);
-                                if ctrl
+                                let res = AuraZbus::new(aura)
                                     .start_tasks(connection, path.clone())
-                                    .await
-                                    .map_err(|e| {
-                                        error!("Failed to start Aura tasks: {e:?}, not adding this device")
-                                    })
-                                    .is_ok()
-                                {
-                                    devices.push(AsusDevice {
-                                        device: dev_type,
-                                        dbus_path: path,
-                                        hid_key: Some(hid_key),
-                                    });
-                                }
+                                    .await;
+                                register_device_zbus(
+                                    &mut devices,
+                                    dev_type,
+                                    path,
+                                    res,
+                                    "Aura",
+                                    Some(hid_key.clone()),
+                                );
                             }
                         }
                     } else {
@@ -385,21 +393,10 @@ impl DeviceManager {
             if let Ok(dev_type) = DeviceHandle::new_slash_usb().await {
                 if let DeviceHandle::Slash(slash) = dev_type.clone() {
                     let path = dbus_path_for_slash();
-                    let ctrl = SlashZbus::new(slash);
-                    if ctrl
+                    let res = SlashZbus::new(slash)
                         .start_tasks(connection, path.clone())
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to start Slash tasks: {e:?}, not adding this device")
-                        })
-                        .is_ok()
-                    {
-                        devices.push(AsusDevice {
-                            device: dev_type,
-                            dbus_path: path,
-                            hid_key: None,
-                        });
-                    }
+                        .await;
+                    register_device_zbus(&mut devices, dev_type, path, res, "Slash", None);
                 }
             } else {
                 info!("Tested device was not Slash");
@@ -408,22 +405,12 @@ impl DeviceManager {
 
         if do_anime {
             if let Ok(dev_type) = DeviceHandle::maybe_anime_usb().await {
-                // TODO: this is copy/pasted
                 if let DeviceHandle::AniMe(anime) = dev_type.clone() {
                     let path = dbus_path_for_anime();
-                    let ctrl = AniMeZbus::new(anime);
-                    if ctrl
+                    let res = AniMeZbus::new(anime)
                         .start_tasks(connection, path.clone())
-                        .await
-                        .map_err(|e| error!("Failed to start tasks: {e:?}, not adding this device"))
-                        .is_ok()
-                    {
-                        devices.push(AsusDevice {
-                            device: dev_type,
-                            dbus_path: path,
-                            hid_key: None,
-                        });
-                    }
+                        .await;
+                    register_device_zbus(&mut devices, dev_type, path, res, "AniMe Matrix", None);
                 }
             } else {
                 info!("Tested device was not AniMe Matrix");
@@ -444,23 +431,10 @@ impl DeviceManager {
                 if let Ok(dev_type) = DeviceHandle::maybe_laptop_aura(None, "tuf").await {
                     if let DeviceHandle::Aura(aura) = dev_type.clone() {
                         let path = dbus_path_for_tuf();
-                        let ctrl = AuraZbus::new(aura);
-                        if ctrl
+                        let res = AuraZbus::new(aura)
                             .start_tasks(connection, path.clone())
-                            .await
-                            .map_err(|e| {
-                                error!(
-                                    "Failed to start TUF Aura tasks: {e:?}, not adding this device"
-                                )
-                            })
-                            .is_ok()
-                        {
-                            devices.push(AsusDevice {
-                                device: dev_type,
-                                dbus_path: path,
-                                hid_key: None,
-                            });
-                        }
+                            .await;
+                        register_device_zbus(&mut devices, dev_type, path, res, "TUF Aura", None);
                     }
                 }
             }

--- a/asusd/src/aura_scsi/trait_impls.rs
+++ b/asusd/src/aura_scsi/trait_impls.rs
@@ -28,8 +28,10 @@ impl ScsiZbus {
             .object_server()
             .at(path.clone(), self)
             .await
-            .map_err(|e| error!("Couldn't add server at path: {path}, {e:?}"))
-            .ok();
+            .map_err(|e| {
+                error!("Couldn't add server at path: {path}, {e:?}");
+                e
+            })?;
         Ok(())
     }
 }

--- a/asusd/src/aura_slash/trait_impls.rs
+++ b/asusd/src/aura_slash/trait_impls.rs
@@ -34,8 +34,10 @@ impl SlashZbus {
             .object_server()
             .at(path.clone(), self)
             .await
-            .map_err(|e| error!("Couldn't add server at path: {path}, {e:?}"))
-            .ok();
+            .map_err(|e| {
+                error!("Couldn't add server at path: {path}, {e:?}");
+                e
+            })?;
         Ok(())
     }
 }

--- a/asusd/src/ctrl_backlight.rs
+++ b/asusd/src/ctrl_backlight.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use config_traits::StdConfig;
-use log::{info, warn};
+use log::{error, info, warn};
 use rog_platform::backlight::{Backlight, BacklightType};
 use tokio::sync::Mutex;
 use zbus::fdo::Error as FdoErr;
@@ -173,20 +173,14 @@ impl CtrlBacklight {
                 use futures_util::StreamExt;
                 if let Ok(mut stream) = watch.into_event_stream(&mut buffer) {
                     loop {
-                        let _ = stream.next().await;
+                        if stream.next().await.is_none() {
+                            info!("Primary backlight event stream closed");
+                            break;
+                        }
 
                         let sync = backlights.config.lock().await.screenpad_sync_primary;
-                        if let Some(sync) = sync {
-                            if !sync {
-                                continue;
-                            }
-                        } else if backlights
-                            .config
-                            .lock()
-                            .await
-                            .screenpad_sync_primary
-                            .is_none()
-                        {
+                        if !sync.unwrap_or(false) {
+                            tokio::time::sleep(Duration::from_millis(300)).await;
                             continue;
                         }
 
@@ -205,6 +199,8 @@ impl CtrlBacklight {
                         // other processes cause "MODIFY" event and make this spin 100%, so sleep
                         tokio::time::sleep(Duration::from_millis(300)).await;
                     }
+                } else {
+                    error!("Primary backlight watcher: into_event_stream initialization failed");
                 }
             });
             return Ok(Some(handle));

--- a/asusd/src/ctrl_backlight.rs
+++ b/asusd/src/ctrl_backlight.rs
@@ -157,12 +157,6 @@ impl CtrlBacklight {
             return Ok(None);
         }
 
-        if let Some(sync) = self.config.lock().await.screenpad_sync_primary {
-            if !sync {
-                return Ok(None);
-            }
-        }
-
         if let Some(backlight) = self.get_backlight(&BacklightType::Primary) {
             let watch = backlight.monitor_brightness()?;
 

--- a/asusd/src/ctrl_backlight.rs
+++ b/asusd/src/ctrl_backlight.rs
@@ -150,14 +150,16 @@ impl CtrlBacklight {
         }
     }
 
-    pub async fn start_watch_primary(&self) -> Result<(), RogError> {
+    pub async fn start_watch_primary(
+        &self,
+    ) -> Result<Option<tokio::task::JoinHandle<()>>, RogError> {
         if self.get_backlight(&BacklightType::Screenpad).is_none() {
-            return Ok(());
+            return Ok(None);
         }
 
         if let Some(sync) = self.config.lock().await.screenpad_sync_primary {
             if !sync {
-                return Ok(());
+                return Ok(None);
             }
         }
 
@@ -165,7 +167,7 @@ impl CtrlBacklight {
             let watch = backlight.monitor_brightness()?;
 
             let backlights = self.clone();
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 let mut last_level = 0;
                 let mut buffer = [0; 32];
                 use futures_util::StreamExt;
@@ -203,16 +205,12 @@ impl CtrlBacklight {
                         // other processes cause "MODIFY" event and make this spin 100%, so sleep
                         tokio::time::sleep(Duration::from_millis(300)).await;
                     }
-                    // watch
-                    //     .into_event_stream(&mut buffer)
-                    //     .unwrap()
-                    //     .for_each(|_| async {})
-                    //     .await;
                 }
             });
+            return Ok(Some(handle));
         }
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -953,6 +953,9 @@ impl CtrlTask for CtrlPlatform {
                                 .set_charge_control_end_threshold(
                                     platform1.config.lock().await.charge_control_end_threshold,
                                 )
+                                .map_err(|err| {
+                                    warn!("CtrlPlatform: failed to restore charge_control_end_threshold: {err}");
+                                })
                                 .ok();
                         }
                         if let Ok(power_plugged) = platform1.power.get_online() {
@@ -1075,7 +1078,9 @@ impl CtrlTask for CtrlPlatform {
             .await?
         {
             tasks.spawn(async move {
-                let _ = h.await;
+                if let Err(err) = h.await {
+                    warn!("charge_control_end_threshold watcher ended with error: {err:?}");
+                }
             });
         }
 

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -1084,48 +1084,59 @@ impl CtrlTask for CtrlPlatform {
             });
         }
 
-        let watch_platform_profile = self.platform.monitor_platform_profile()?;
-        let ctrl = self.clone();
+        match self.platform.monitor_platform_profile() {
+            Ok(watch_platform_profile) => {
+                let ctrl = self.clone();
 
-        // Need a copy here, not ideal. But first use in asus_armoury.rs is
-        // moved to zbus
-        let attrs = FirmwareAttributes::new();
-        tasks.spawn(async move {
-            use futures_util::StreamExt;
-            let mut buffer = [0; 32];
-            if let Ok(mut stream) = watch_platform_profile.into_event_stream(&mut buffer) {
-                while (stream.next().await).is_some() {
-                    debug!("Platform: watch_platform_profile changed");
-                    if let Ok(profile) = ctrl
-                        .platform
-                        .get_platform_profile()
-                        .map(|p| p.into())
-                        .map_err(|e| {
-                            error!("Platform: get_platform_profile error: {e}");
-                        })
-                    {
-                        let change_epp = ctrl.config.lock().await.platform_profile_linked_epp;
-                        let epp = ctrl.get_config_epp_for_throttle(profile).await;
-                        ctrl.check_and_set_epp(epp, change_epp);
-                        ctrl.platform_profile_changed(&signal_ctxt_copy).await.ok();
-                        ctrl.enable_ppt_group_changed(&signal_ctxt_copy).await.ok();
-                        let power_plugged = ctrl
-                            .power
-                            .get_online()
-                            .map_err(|e| {
-                                error!("Could not get power status: {e:?}");
-                                e
-                            })
-                            .unwrap_or_default();
-                        ctrl.apply_fan_curves_and_ppt(&attrs, power_plugged == 1, profile)
-                            .await;
-                        if let Err(e) = ctrl.armoury_registry.emit_limits(&ctrl.connection).await {
-                            error!("Failed to emit armoury updates after profile change: {e:?}");
+                // Need a copy here, not ideal. But first use in asus_armoury.rs is
+                // moved to zbus
+                let attrs = FirmwareAttributes::new();
+                tasks.spawn(async move {
+                    use futures_util::StreamExt;
+                    let mut buffer = [0; 32];
+                    if let Ok(mut stream) = watch_platform_profile.into_event_stream(&mut buffer) {
+                        while (stream.next().await).is_some() {
+                            debug!("Platform: watch_platform_profile changed");
+                            if let Ok(profile) = ctrl
+                                .platform
+                                .get_platform_profile()
+                                .map(|p| p.into())
+                                .map_err(|e| {
+                                    error!("Platform: get_platform_profile error: {e}");
+                                })
+                            {
+                                let change_epp =
+                                    ctrl.config.lock().await.platform_profile_linked_epp;
+                                let epp = ctrl.get_config_epp_for_throttle(profile).await;
+                                ctrl.check_and_set_epp(epp, change_epp);
+                                ctrl.platform_profile_changed(&signal_ctxt_copy).await.ok();
+                                ctrl.enable_ppt_group_changed(&signal_ctxt_copy).await.ok();
+                                let power_plugged = ctrl
+                                    .power
+                                    .get_online()
+                                    .map_err(|e| {
+                                        error!("Could not get power status: {e:?}");
+                                        e
+                                    })
+                                    .unwrap_or_default();
+                                ctrl.apply_fan_curves_and_ppt(&attrs, power_plugged == 1, profile)
+                                    .await;
+                                if let Err(e) =
+                                    ctrl.armoury_registry.emit_limits(&ctrl.connection).await
+                                {
+                                    error!("Failed to emit armoury updates after profile change: {e:?}");
+                                }
+                            }
                         }
+                    } else {
+                        error!("Platform: watch_platform_profile into_event_stream failed");
                     }
-                }
+                });
             }
-        });
+            Err(e) => {
+                error!("Platform: monitor_platform_profile failed: {e:?}, profile-change watcher disabled");
+            }
+        }
 
         Self::spawn_task_supervisor("CtrlPlatform", tasks);
 

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -1073,15 +1073,21 @@ impl CtrlTask for CtrlPlatform {
             )
             .await?;
 
-        if let Some(h) = self
+        match self
             .watch_charge_control_end_threshold(signal_ctxt_copy.clone())
-            .await?
+            .await
         {
-            tasks.spawn(async move {
-                if let Err(err) = h.await {
-                    warn!("charge_control_end_threshold watcher ended with error: {err:?}");
-                }
-            });
+            Ok(Some(h)) => {
+                tasks.spawn(async move {
+                    if let Err(err) = h.await {
+                        warn!("charge_control_end_threshold watcher ended with error: {err:?}");
+                    }
+                });
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!("Platform: watch_charge_control_end_threshold: {err}");
+            }
         }
 
         match self.platform.monitor_platform_profile() {

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -1066,7 +1066,7 @@ impl CtrlTask for CtrlPlatform {
                 }
             },
         )
-        .await;
+        .await?;
 
         // This spawns a new task for every item.
         // TODO: find a better way to manage this

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -1127,13 +1127,7 @@ impl CtrlTask for CtrlPlatform {
             }
         });
 
-        tokio::spawn(async move {
-            while let Some(res) = tasks.join_next().await {
-                if let Err(err) = res {
-                    warn!("CtrlPlatform background task ended with error: {err:?}");
-                }
-            }
-        });
+        Self::spawn_task_supervisor("CtrlPlatform", tasks);
 
         Ok(())
     }

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -933,145 +933,151 @@ impl CtrlTask for CtrlPlatform {
         let platform2 = self.clone();
         let platform3 = self.clone();
         let signal_ctxt_copy = signal_ctxt.clone();
-        self.create_sys_event_tasks(
-            move |sleeping| {
-                let platform1 = platform1.clone();
-                async move {
-                    // This block is commented out due to some kind of issue reported. Maybe the
-                    // desktops used were storing a value whcih was then read here.
-                    // Don't store it on suspend, assume that the current config setting is desired
-                    // if sleeping && platform1.power.has_charge_control_end_threshold() {
-                    //     platform1.config.lock().await.charge_control_end_threshold = platform1
-                    //         .power
-                    //         .get_charge_control_end_threshold()
-                    //         .unwrap_or(100);
-                    // } else
-                    if !sleeping && platform1.power.has_charge_control_end_threshold() {
-                        platform1
-                            .power
-                            .set_charge_control_end_threshold(
-                                platform1.config.lock().await.charge_control_end_threshold,
-                            )
-                            .ok();
-                    }
-                    if let Ok(power_plugged) = platform1.power.get_online() {
-                        if platform1.config.lock().await.last_power_plugged != power_plugged {
-                            if !sleeping && platform1.platform.has_platform_profile() {
-                                let change_epp =
-                                    platform1.config.lock().await.platform_profile_linked_epp;
-                                platform1
-                                    .update_policy_ac_or_bat(power_plugged > 0, change_epp)
-                                    .await;
-                            }
-                            if !sleeping {
-                                platform1.run_ac_or_bat_cmd(power_plugged > 0).await;
-                                if let Ok(profile) =
-                                    platform1.platform.get_platform_profile().map(|p| p.into())
-                                {
-                                    let attrs = FirmwareAttributes::new();
+        let mut tasks = self
+            .create_sys_event_tasks(
+                move |sleeping| {
+                    let platform1 = platform1.clone();
+                    async move {
+                        // This block is commented out due to some kind of issue reported. Maybe the
+                        // desktops used were storing a value whcih was then read here.
+                        // Don't store it on suspend, assume that the current config setting is desired
+                        // if sleeping && platform1.power.has_charge_control_end_threshold() {
+                        //     platform1.config.lock().await.charge_control_end_threshold = platform1
+                        //         .power
+                        //         .get_charge_control_end_threshold()
+                        //         .unwrap_or(100);
+                        // } else
+                        if !sleeping && platform1.power.has_charge_control_end_threshold() {
+                            platform1
+                                .power
+                                .set_charge_control_end_threshold(
+                                    platform1.config.lock().await.charge_control_end_threshold,
+                                )
+                                .ok();
+                        }
+                        if let Ok(power_plugged) = platform1.power.get_online() {
+                            if platform1.config.lock().await.last_power_plugged != power_plugged {
+                                if !sleeping && platform1.platform.has_platform_profile() {
+                                    let change_epp =
+                                        platform1.config.lock().await.platform_profile_linked_epp;
                                     platform1
-                                        .apply_fan_curves_and_ppt(
-                                            &attrs,
-                                            power_plugged > 0,
-                                            profile,
-                                        )
+                                        .update_policy_ac_or_bat(power_plugged > 0, change_epp)
                                         .await;
-                                    if let Err(e) = platform1
-                                        .armoury_registry
-                                        .emit_limits(&platform1.connection)
-                                        .await
+                                }
+                                if !sleeping {
+                                    platform1.run_ac_or_bat_cmd(power_plugged > 0).await;
+                                    if let Ok(profile) =
+                                        platform1.platform.get_platform_profile().map(|p| p.into())
                                     {
-                                        error!(
+                                        let attrs = FirmwareAttributes::new();
+                                        platform1
+                                            .apply_fan_curves_and_ppt(
+                                                &attrs,
+                                                power_plugged > 0,
+                                                profile,
+                                            )
+                                            .await;
+                                        if let Err(e) = platform1
+                                            .armoury_registry
+                                            .emit_limits(&platform1.connection)
+                                            .await
+                                        {
+                                            error!(
                                             "Failed to emit armoury updates after power change: \
                                              {e:?}"
                                         );
+                                        }
                                     }
                                 }
+                                platform1.config.lock().await.last_power_plugged = power_plugged;
                             }
-                            platform1.config.lock().await.last_power_plugged = power_plugged;
                         }
                     }
-                }
-            },
-            move |shutting_down| {
-                let platform2 = platform2.clone();
-                async move {
-                    info!("RogPlatform reloading panel_od");
-                    let lock = platform2.config.lock().await;
-                    if shutting_down
-                        && platform2.power.has_charge_control_end_threshold()
-                        && lock.base_charge_control_end_threshold > 0
-                    {
-                        info!("RogPlatform restoring charge_control_end_threshold");
-                        platform2
-                            .power
-                            .set_charge_control_end_threshold(
-                                lock.base_charge_control_end_threshold,
-                            )
-                            .map_err(|err| {
-                                warn!("CtrlCharge: charge_control_end_threshold {}", err);
-                                err
-                            })
-                            .ok();
-                    }
-                }
-            },
-            move |_lid_closed| {
-                // on lid change
-                async move {}
-            },
-            move |power_plugged| {
-                let platform3 = platform3.clone();
-                let signal_ctxt_copy = signal_ctxt.clone();
-                // power change
-                async move {
-                    if platform3.platform.has_platform_profile() {
-                        let change_epp = platform3.config.lock().await.platform_profile_linked_epp;
-                        platform3
-                            .update_policy_ac_or_bat(power_plugged, change_epp)
-                            .await;
-                    }
-                    platform3.run_ac_or_bat_cmd(power_plugged).await;
-                    platform3.manage_nvidia_powerd(power_plugged).await;
-                    // In case one-shot charge was used, restore the old charge limit
-                    if platform3.power.has_charge_control_end_threshold() && !power_plugged {
-                        platform3.restore_charge_limit().await;
-                    }
-
-                    if let Ok(profile) = platform3
-                        .platform
-                        .get_platform_profile()
-                        .map(|p| p.into())
-                        .map_err(|e| {
-                            error!("Platform: get_platform_profile error: {e}");
-                        })
-                    {
-                        // TODO: manage this better, shouldn't need to create every time
-                        let attrs = FirmwareAttributes::new();
-                        platform3
-                            .apply_fan_curves_and_ppt(&attrs, power_plugged, profile)
-                            .await;
-                        if let Err(e) = platform3
-                            .armoury_registry
-                            .emit_limits(&platform3.connection)
-                            .await
+                },
+                move |shutting_down| {
+                    let platform2 = platform2.clone();
+                    async move {
+                        info!("RogPlatform reloading panel_od");
+                        let lock = platform2.config.lock().await;
+                        if shutting_down
+                            && platform2.power.has_charge_control_end_threshold()
+                            && lock.base_charge_control_end_threshold > 0
                         {
-                            error!("Failed to emit armoury updates after AC/DC toggle: {e:?}");
+                            info!("RogPlatform restoring charge_control_end_threshold");
+                            platform2
+                                .power
+                                .set_charge_control_end_threshold(
+                                    lock.base_charge_control_end_threshold,
+                                )
+                                .map_err(|err| {
+                                    warn!("CtrlCharge: charge_control_end_threshold {}", err);
+                                    err
+                                })
+                                .ok();
                         }
-                        platform3
-                            .enable_ppt_group_changed(&signal_ctxt_copy)
-                            .await
-                            .ok();
                     }
-                }
-            },
-        )
-        .await?;
+                },
+                move |_lid_closed| {
+                    // on lid change
+                    async move {}
+                },
+                move |power_plugged| {
+                    let platform3 = platform3.clone();
+                    let signal_ctxt_copy = signal_ctxt.clone();
+                    // power change
+                    async move {
+                        if platform3.platform.has_platform_profile() {
+                            let change_epp =
+                                platform3.config.lock().await.platform_profile_linked_epp;
+                            platform3
+                                .update_policy_ac_or_bat(power_plugged, change_epp)
+                                .await;
+                        }
+                        platform3.run_ac_or_bat_cmd(power_plugged).await;
+                        platform3.manage_nvidia_powerd(power_plugged).await;
+                        // In case one-shot charge was used, restore the old charge limit
+                        if platform3.power.has_charge_control_end_threshold() && !power_plugged {
+                            platform3.restore_charge_limit().await;
+                        }
 
-        // This spawns a new task for every item.
-        // TODO: find a better way to manage this
-        self.watch_charge_control_end_threshold(signal_ctxt_copy.clone())
+                        if let Ok(profile) = platform3
+                            .platform
+                            .get_platform_profile()
+                            .map(|p| p.into())
+                            .map_err(|e| {
+                                error!("Platform: get_platform_profile error: {e}");
+                            })
+                        {
+                            // TODO: manage this better, shouldn't need to create every time
+                            let attrs = FirmwareAttributes::new();
+                            platform3
+                                .apply_fan_curves_and_ppt(&attrs, power_plugged, profile)
+                                .await;
+                            if let Err(e) = platform3
+                                .armoury_registry
+                                .emit_limits(&platform3.connection)
+                                .await
+                            {
+                                error!("Failed to emit armoury updates after AC/DC toggle: {e:?}");
+                            }
+                            platform3
+                                .enable_ppt_group_changed(&signal_ctxt_copy)
+                                .await
+                                .ok();
+                        }
+                    }
+                },
+            )
             .await?;
+
+        if let Some(h) = self
+            .watch_charge_control_end_threshold(signal_ctxt_copy.clone())
+            .await?
+        {
+            tasks.spawn(async move {
+                let _ = h.await;
+            });
+        }
 
         let watch_platform_profile = self.platform.monitor_platform_profile()?;
         let ctrl = self.clone();
@@ -1079,12 +1085,11 @@ impl CtrlTask for CtrlPlatform {
         // Need a copy here, not ideal. But first use in asus_armoury.rs is
         // moved to zbus
         let attrs = FirmwareAttributes::new();
-        tokio::spawn(async move {
+        tasks.spawn(async move {
             use futures_util::StreamExt;
             let mut buffer = [0; 32];
             if let Ok(mut stream) = watch_platform_profile.into_event_stream(&mut buffer) {
                 while (stream.next().await).is_some() {
-                    // this blocks
                     debug!("Platform: watch_platform_profile changed");
                     if let Ok(profile) = ctrl
                         .platform
@@ -1113,6 +1118,14 @@ impl CtrlTask for CtrlPlatform {
                             error!("Failed to emit armoury updates after profile change: {e:?}");
                         }
                     }
+                }
+            }
+        });
+
+        tokio::spawn(async move {
+            while let Some(res) = tasks.join_next().await {
+                if let Err(err) = res {
+                    warn!("CtrlPlatform background task ended with error: {err:?}");
                 }
             }
         });

--- a/asusd/src/daemon.rs
+++ b/asusd/src/daemon.rs
@@ -117,12 +117,18 @@ async fn start_daemon() -> Result<(), Box<dyn Error>> {
     match CtrlBacklight::new(config.clone()) {
         Ok(backlight) => {
             info!("Backlight: found supported backlight");
-            if let Some(handle) = backlight.start_watch_primary().await? {
-                tokio::spawn(async move {
-                    if let Err(err) = handle.await {
-                        warn!("Backlight watcher task ended with error: {err:?}");
-                    }
-                });
+            match backlight.start_watch_primary().await {
+                Ok(Some(handle)) => {
+                    tokio::spawn(async move {
+                        if let Err(err) = handle.await {
+                            warn!("Backlight watcher task ended with error: {err:?}");
+                        }
+                    });
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    warn!("Backlight: start_watch_primary: {err}");
+                }
             }
             backlight.add_to_server(&mut server).await;
             info!("Backlight: initialized");

--- a/asusd/src/daemon.rs
+++ b/asusd/src/daemon.rs
@@ -34,11 +34,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let is_service = match env::var_os("IS_SERVICE") {
         Some(val) => val == "1",
-        None => true,
+        None => false,
     };
 
     if !is_service {
-        println!("asusd schould be only run from the right systemd service");
+        println!("asusd should be only run from the right systemd service");
         println!(
             "do not run in your terminal, if you need an logs please use journalctl -b -u asusd"
         );
@@ -117,7 +117,13 @@ async fn start_daemon() -> Result<(), Box<dyn Error>> {
     match CtrlBacklight::new(config.clone()) {
         Ok(backlight) => {
             info!("Backlight: found supported backlight");
-            backlight.start_watch_primary().await?;
+            if let Some(handle) = backlight.start_watch_primary().await? {
+                tokio::spawn(async move {
+                    if let Err(err) = handle.await {
+                        warn!("Backlight watcher task ended with error: {err:?}");
+                    }
+                });
+            }
             backlight.add_to_server(&mut server).await;
             info!("Backlight: initialized");
         }

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -233,10 +233,10 @@ pub trait CtrlTask {
         F2: FnMut(bool) -> Fut2 + Send + 'static,
         F3: FnMut(bool) -> Fut3 + Send + 'static,
         F4: FnMut(bool) -> Fut4 + Send + 'static,
-        Fut1: Future<Output = ()> + Send,
-        Fut2: Future<Output = ()> + Send,
-        Fut3: Future<Output = ()> + Send,
-        Fut4: Future<Output = ()> + Send,
+        Fut1: Future<Output = ()> + Send + 'static,
+        Fut2: Future<Output = ()> + Send + 'static,
+        Fut3: Future<Output = ()> + Send + 'static,
+        Fut4: Future<Output = ()> + Send + 'static,
     {
         async move {
             let connection = Connection::system().await.map_err(RogError::Zbus)?;

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -221,7 +221,7 @@ pub trait CtrlTask {
         mut on_prepare_for_shutdown: F2,
         mut on_lid_change: F3,
         mut on_external_power_change: F4,
-    ) -> impl Future<Output = ()> + Send
+    ) -> impl Future<Output = Result<(), RogError>> + Send
     where
         F1: FnMut(bool) -> Fut1 + Send + 'static,
         F2: FnMut(bool) -> Fut2 + Send + 'static,
@@ -232,22 +232,19 @@ pub trait CtrlTask {
         Fut3: Future<Output = ()> + Send,
         Fut4: Future<Output = ()> + Send,
     {
-        async {
-            let connection = Connection::system()
-                .await
-                .expect("Controller could not create dbus connection");
+        async move {
+            let connection = Connection::system().await.map_err(RogError::Zbus)?;
 
             let manager = ManagerProxy::builder(&connection)
                 .cache_properties(CacheProperties::No)
                 .build()
                 .await
-                .expect("Controller could not create ManagerProxy");
+                .map_err(RogError::Zbus)?;
 
             let manager1 = manager.clone();
             tokio::spawn(async move {
                 if let Ok(mut notif) = manager1.receive_prepare_for_shutdown().await {
                     while let Some(event) = notif.next().await {
-                        // blocks thread :|
                         if let Ok(args) = event.args() {
                             debug!("Doing on_prepare_for_shutdown({})", args.start);
                             on_prepare_for_shutdown(args.start).await;
@@ -260,7 +257,6 @@ pub trait CtrlTask {
             tokio::spawn(async move {
                 if let Ok(mut notif) = manager2.receive_prepare_for_sleep().await {
                     while let Some(event) = notif.next().await {
-                        // blocks thread :|
                         if let Ok(args) = event.args() {
                             debug!("Doing on_prepare_for_sleep({})", args.start);
                             on_prepare_for_sleep(args.start).await;
@@ -286,7 +282,6 @@ pub trait CtrlTask {
 
             tokio::spawn(async move {
                 let mut last_lid = manager.lid_closed().await.unwrap_or_default();
-                // need to loop on these as they don't emit signals
                 loop {
                     if let Ok(next) = manager.lid_closed().await {
                         if next != last_lid {
@@ -297,6 +292,8 @@ pub trait CtrlTask {
                     sleep(Duration::from_secs(2)).await;
                 }
             });
+
+            Ok(())
         }
     }
 }

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -205,6 +205,17 @@ pub trait CtrlTask {
         signal: SignalEmitter<'static>,
     ) -> impl Future<Output = Result<(), RogError>> + Send;
 
+    /// Helper to spawn a background task that drains JoinSet and logs any task errors.
+    fn spawn_task_supervisor(name: &'static str, mut tasks: tokio::task::JoinSet<()>) {
+        tokio::spawn(async move {
+            while let Some(res) = tasks.join_next().await {
+                if let Err(err) = res {
+                    warn!("{name} background task ended with error: {err:?}");
+                }
+            }
+        });
+    }
+
     // /// Create a timed repeating task
     // async fn repeating_task(&self, millis: u64, mut task: impl FnMut() + Send +
     // 'static) {     use std::time::Duration;

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -68,14 +68,14 @@ macro_rules! task_watch_item {
         async fn fn_name(
             &self,
             signal_ctxt: SignalEmitter<'static>,
-        ) -> Result<(), RogError> {
+        ) -> Result<Option<tokio::task::JoinHandle<()>>, RogError> {
             use futures_util::StreamExt;
 
             let ctrl = self.clone();
             concat_idents::concat_idents!(watch_fn = monitor_, $name {
                 match self.$self_inner.watch_fn() {
                     Ok(watch) => {
-                        tokio::spawn(async move {
+                        let handle = tokio::spawn(async move {
                             let mut buffer = [0; 32];
                             if let Ok(stream) = watch.into_event_stream(&mut buffer) {
                                 stream.for_each(|_| async {
@@ -95,11 +95,14 @@ macro_rules! task_watch_item {
                                 log::error!("Failed to create event stream for {}", $name_str);
                             }
                         });
+                        Ok(Some(handle))
                     }
-                    Err(e) => info!("inotify watch failed: {}. You can ignore this if your device does not support the feature", e),
+                    Err(e) => {
+                        info!("inotify watch failed: {}. You can ignore this if your device does not support the feature", e);
+                        Ok(None)
+                    }
                 }
-            });
-            Ok(())
+            })
         }
         });
     };
@@ -112,14 +115,14 @@ macro_rules! task_watch_item_notify {
         async fn fn_name(
             &self,
             signal_ctxt: SignalEmitter<'static>,
-        ) -> Result<(), RogError> {
+        ) -> Result<Option<tokio::task::JoinHandle<()>>, RogError> {
             use futures_util::StreamExt;
 
             let ctrl = self.clone();
             concat_idents::concat_idents!(watch_fn = monitor_, $name {
                 match self.$self_inner.watch_fn() {
                     Ok(watch) => {
-                        tokio::spawn(async move {
+                        let handle = tokio::spawn(async move {
                             let mut buffer = [0; 32];
                             if let Ok(stream) = watch.into_event_stream(&mut buffer) {
                                 stream.for_each(|_| async {
@@ -129,11 +132,14 @@ macro_rules! task_watch_item_notify {
                                 }).await;
                             }
                         });
+                        Ok(Some(handle))
                     }
-                    Err(e) => info!("inotify watch failed: {}. You can ignore this if your device does not support the feature", e),
+                    Err(e) => {
+                        info!("inotify watch failed: {}. You can ignore this if your device does not support the feature", e);
+                        Ok(None)
+                    }
                 }
-            });
-            Ok(())
+            })
         }
         });
     };
@@ -221,7 +227,7 @@ pub trait CtrlTask {
         mut on_prepare_for_shutdown: F2,
         mut on_lid_change: F3,
         mut on_external_power_change: F4,
-    ) -> impl Future<Output = Result<(), RogError>> + Send
+    ) -> impl Future<Output = Result<tokio::task::JoinSet<()>, RogError>> + Send
     where
         F1: FnMut(bool) -> Fut1 + Send + 'static,
         F2: FnMut(bool) -> Fut2 + Send + 'static,
@@ -241,8 +247,10 @@ pub trait CtrlTask {
                 .await
                 .map_err(RogError::Zbus)?;
 
+            let mut set = tokio::task::JoinSet::new();
+
             let manager1 = manager.clone();
-            tokio::spawn(async move {
+            set.spawn(async move {
                 if let Ok(mut notif) = manager1.receive_prepare_for_shutdown().await {
                     while let Some(event) = notif.next().await {
                         if let Ok(args) = event.args() {
@@ -254,7 +262,7 @@ pub trait CtrlTask {
             });
 
             let manager2 = manager.clone();
-            tokio::spawn(async move {
+            set.spawn(async move {
                 if let Ok(mut notif) = manager2.receive_prepare_for_sleep().await {
                     while let Some(event) = notif.next().await {
                         if let Ok(args) = event.args() {
@@ -266,7 +274,7 @@ pub trait CtrlTask {
             });
 
             let manager3 = manager.clone();
-            tokio::spawn(async move {
+            set.spawn(async move {
                 let mut last_power = manager3.on_external_power().await.unwrap_or_default();
 
                 loop {
@@ -280,7 +288,7 @@ pub trait CtrlTask {
                 }
             });
 
-            tokio::spawn(async move {
+            set.spawn(async move {
                 let mut last_lid = manager.lid_closed().await.unwrap_or_default();
                 loop {
                     if let Ok(next) = manager.lid_closed().await {
@@ -293,7 +301,7 @@ pub trait CtrlTask {
                 }
             });
 
-            Ok(())
+            Ok(set)
         }
     }
 }

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use dmi_id::DMIID;
 use futures_util::stream::StreamExt;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use logind_zbus::manager::ManagerProxy;
 use tokio::time::sleep;
 use zbus::object_server::{Interface, SignalEmitter};
@@ -268,37 +268,75 @@ pub trait CtrlTask {
 
             let manager1 = manager.clone();
             set.spawn(async move {
-                if let Ok(mut notif) = manager1.receive_prepare_for_shutdown().await {
-                    while let Some(event) = notif.next().await {
-                        if let Ok(args) = event.args() {
-                            debug!("Doing on_prepare_for_shutdown({})", args.start);
-                            on_prepare_for_shutdown(args.start).await;
+                match manager1.receive_prepare_for_shutdown().await {
+                    Ok(mut notif) => {
+                        while let Some(event) = notif.next().await {
+                            match event.args() {
+                                Ok(args) => {
+                                    debug!("Doing on_prepare_for_shutdown({})", args.start);
+                                    on_prepare_for_shutdown(args.start).await;
+                                }
+                                Err(err) => {
+                                    error!("Prepare for shutdown event args error: {err}");
+                                }
+                            }
                         }
+                        warn!("Prepare for shutdown notification stream closed");
+                    }
+                    Err(err) => {
+                        error!("Failed to subscribe to prepare_for_shutdown signal: {err}");
                     }
                 }
             });
 
             let manager2 = manager.clone();
             set.spawn(async move {
-                if let Ok(mut notif) = manager2.receive_prepare_for_sleep().await {
-                    while let Some(event) = notif.next().await {
-                        if let Ok(args) = event.args() {
-                            debug!("Doing on_prepare_for_sleep({})", args.start);
-                            on_prepare_for_sleep(args.start).await;
+                match manager2.receive_prepare_for_sleep().await {
+                    Ok(mut notif) => {
+                        while let Some(event) = notif.next().await {
+                            match event.args() {
+                                Ok(args) => {
+                                    debug!("Doing on_prepare_for_sleep({})", args.start);
+                                    on_prepare_for_sleep(args.start).await;
+                                }
+                                Err(err) => {
+                                    error!("Prepare for sleep event args error: {err}");
+                                }
+                            }
                         }
+                        warn!("Prepare for sleep notification stream closed");
+                    }
+                    Err(err) => {
+                        error!("Failed to subscribe to prepare_for_sleep signal: {err}");
                     }
                 }
             });
 
             let manager3 = manager.clone();
             set.spawn(async move {
-                let mut last_power = manager3.on_external_power().await.unwrap_or_default();
+                let mut last_power = match manager3.on_external_power().await {
+                    Ok(p) => p,
+                    Err(err) => {
+                        error!("Failed to read initial on_external_power property: {err}");
+                        false
+                    }
+                };
 
+                let mut in_error_state = false;
                 loop {
-                    if let Ok(next) = manager3.on_external_power().await {
-                        if next != last_power {
-                            last_power = next;
-                            on_external_power_change(next).await;
+                    match manager3.on_external_power().await {
+                        Ok(next) => {
+                            in_error_state = false;
+                            if next != last_power {
+                                last_power = next;
+                                on_external_power_change(next).await;
+                            }
+                        }
+                        Err(err) => {
+                            if !in_error_state {
+                                warn!("Failed to read on_external_power property: {err}");
+                                in_error_state = true;
+                            }
                         }
                     }
                     sleep(Duration::from_secs(2)).await;
@@ -306,12 +344,29 @@ pub trait CtrlTask {
             });
 
             set.spawn(async move {
-                let mut last_lid = manager.lid_closed().await.unwrap_or_default();
+                let mut last_lid = match manager.lid_closed().await {
+                    Ok(l) => l,
+                    Err(err) => {
+                        error!("Failed to read initial lid_closed property: {err}");
+                        false
+                    }
+                };
+
+                let mut in_error_state = false;
                 loop {
-                    if let Ok(next) = manager.lid_closed().await {
-                        if next != last_lid {
-                            last_lid = next;
-                            on_lid_change(next).await;
+                    match manager.lid_closed().await {
+                        Ok(next) => {
+                            in_error_state = false;
+                            if next != last_lid {
+                                last_lid = next;
+                                on_lid_change(next).await;
+                            }
+                        }
+                        Err(err) => {
+                            if !in_error_state {
+                                warn!("Failed to read lid_closed property: {err}");
+                                in_error_state = true;
+                            }
                         }
                     }
                     sleep(Duration::from_secs(2)).await;

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -230,6 +230,12 @@ pub trait CtrlTask {
     /// Free helper method to create tasks to run on: sleep, wake, shutdown,
     /// boot
     ///
+    /// # Ownership & Lifetime Contract
+    /// Callers receive an owned [`tokio::task::JoinSet`]. Callers **must** hand off
+    /// ownership to a task supervisor (e.g. via `spawn_task_supervisor`) before
+    /// performing any fallible operations with `?`. Dropping the returned `JoinSet`
+    /// immediately aborts all spawned system event listeners.
+    ///
     /// The closures can potentially block, so execution time should be the
     /// minimal possible such as save a variable.
     fn create_sys_event_tasks<Fut1, Fut2, Fut3, Fut4, F1, F2, F3, F4>(


### PR DESCRIPTION
## Description

This PR enhances `asusd` daemon stability and safety by centralizing Tokio async task supervision, eliminating `.unwrap()` panics in system event handlers, and deduplicating D-Bus registration boilerplate across controller modules.

### Key Changes

* **Async Task Supervision & Lifetime Management**:
  - Centralized task supervision by introducing `CtrlTask::spawn_task_supervisor(name, join_set)` helper in `asusd/src/lib.rs`.
  - Updated `create_sys_event_tasks` and task watch macros (`task_watch_item!`) to return `JoinSet<()>` and `JoinHandle<()>`, ensuring background task errors (suspend/resume, power plug, lid events) are logged instead of swallowed or lost.
  - Fixed backlight watcher handles to prevent background task lifetimes from terminating prematurely.

* **Panic Elimination (`.unwrap()` Removal)**:
  - Replaced blind `.unwrap()` calls in `CtrlKbdLedTask` and system event callbacks with non-blocking error propagation and log warnings (`if let Err(e) = ...`).
  - Updated `create_sys_event_tasks` to return `Result<(), RogError>` rather than panicking on event watcher initialization failure.

* **ZBus Device Registration Boilerplate**:
  - Unified D-Bus server registration logic using `Self::add_to_server_helper` across `aura_anime`, `aura_laptop`, `ctrl_platform`, and `ctrl_backlight`.
* **Daemon & Environment Fixes**:
  - Corrected `IS_SERVICE` environment check for reliable systemd service detection.
  - Cleaned up battery charge threshold log messages and formatting.
