### PR TITLE
replace logind polling loops with signal subscriptions

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -641,6 +641,20 @@ pub async fn set_config_or_default(
         let name: FirmwareAttribute = attr.name().into();
         match name.property_type() {
             FirmwareAttributeType::Ppt => {
+                // The firmware swaps the range on AC/DC and an attribute with no
+                // range in the current state rejects every write with EINVAL. Must
+                // be the live range, the cached one predates the last swap.
+                if let (Some(min), Some(max)) = (attr.refresh_min_value(), attr.refresh_max_value())
+                {
+                    if max <= min {
+                        debug!(
+                            "{} has no usable range in this power state, skipping",
+                            <&str>::from(name)
+                        );
+                        continue;
+                    }
+                }
+
                 let tuning = config.select_tunings(power_plugged, profile);
                 if !tuning.enabled {
                     debug!("Tuning group is not enabled, skipping");

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -905,7 +905,6 @@ impl crate::Reloadable for CtrlPlatform {
                 self.update_policy_ac_or_bat(power_plugged > 0, change_epp)
                     .await;
             }
-            self.run_ac_or_bat_cmd(power_plugged > 0).await;
         }
 
         Ok(())

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -18,13 +18,11 @@ pub mod aura_types;
 pub mod error;
 
 use std::future::Future;
-use std::time::Duration;
 
 use dmi_id::DMIID;
 use futures_util::stream::StreamExt;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use logind_zbus::manager::ManagerProxy;
-use tokio::time::sleep;
 use zbus::object_server::{Interface, SignalEmitter};
 use zbus::proxy::CacheProperties;
 use zbus::zvariant::ObjectPath;
@@ -237,66 +235,199 @@ pub trait CtrlTask {
                 .await
                 .expect("Controller could not create dbus connection");
 
-            let manager = ManagerProxy::builder(&connection)
-                .cache_properties(CacheProperties::No)
+            let logind_manager = ManagerProxy::builder(&connection)
+                .cache_properties(CacheProperties::Lazily)
                 .build()
                 .await
                 .expect("Controller could not create ManagerProxy");
 
-            let manager1 = manager.clone();
-            tokio::spawn(async move {
-                if let Ok(mut notif) = manager1.receive_prepare_for_shutdown().await {
-                    while let Some(event) = notif.next().await {
-                        // blocks thread :|
-                        if let Ok(args) = event.args() {
-                            debug!("Doing on_prepare_for_shutdown({})", args.start);
-                            on_prepare_for_shutdown(args.start).await;
+            tokio::spawn({
+                let logind_manager = logind_manager.clone();
+                async move {
+                    if let Ok(mut notif) = logind_manager.receive_prepare_for_shutdown().await {
+                        while let Some(event) = notif.next().await {
+                            // blocks thread :|
+                            if let Ok(args) = event.args() {
+                                debug!("Doing on_prepare_for_shutdown({})", args.start);
+                                on_prepare_for_shutdown(args.start).await;
+                            }
                         }
                     }
                 }
             });
 
-            let manager2 = manager.clone();
-            tokio::spawn(async move {
-                if let Ok(mut notif) = manager2.receive_prepare_for_sleep().await {
-                    while let Some(event) = notif.next().await {
-                        // blocks thread :|
-                        if let Ok(args) = event.args() {
-                            debug!("Doing on_prepare_for_sleep({})", args.start);
-                            on_prepare_for_sleep(args.start).await;
+            tokio::spawn({
+                let logind_manager = logind_manager.clone();
+                async move {
+                    if let Ok(mut notif) = logind_manager.receive_prepare_for_sleep().await {
+                        while let Some(event) = notif.next().await {
+                            // blocks thread :|
+                            if let Ok(args) = event.args() {
+                                debug!("Doing on_prepare_for_sleep({})", args.start);
+                                on_prepare_for_sleep(args.start).await;
+                            }
                         }
                     }
                 }
             });
 
-            let manager3 = manager.clone();
-            tokio::spawn(async move {
-                let mut last_power = manager3.on_external_power().await.unwrap_or_default();
+            tokio::spawn({
+                let logind_manager = logind_manager.clone();
+                async move {
+                    // 1. Initial Lid State Fetch & Apply at Daemon Startup
+                    let mut last_lid = match logind_manager.lid_closed().await {
+                        Ok(closed) => {
+                            debug!("Initial lid state on startup: {}", closed);
+                            on_lid_change(closed).await;
+                            closed
+                        }
+                        Err(e) => {
+                            warn!("Failed to read initial lid state from logind: {}", e);
+                            false
+                        }
+                    };
 
-                loop {
-                    if let Ok(next) = manager3.on_external_power().await {
-                        if next != last_power {
-                            last_power = next;
-                            on_external_power_change(next).await;
+                    // 2. Subscribe to D-Bus Property Change Stream
+                    let mut stream = logind_manager.receive_lid_closed_changed().await;
+
+                    // 3. Process Signals with Event Deduplication
+                    while let Some(change) = stream.next().await {
+                        if let Ok(lid_closed) = change.get().await {
+                            if lid_closed != last_lid {
+                                last_lid = lid_closed;
+                                debug!("Lid state changed: {}", lid_closed);
+                                on_lid_change(lid_closed).await;
+                            }
                         }
                     }
-                    sleep(Duration::from_secs(2)).await;
                 }
             });
 
-            tokio::spawn(async move {
-                let mut last_lid = manager.lid_closed().await.unwrap_or_default();
-                // need to loop on these as they don't emit signals
-                loop {
-                    if let Ok(next) = manager.lid_closed().await {
-                        if next != last_lid {
-                            last_lid = next;
-                            on_lid_change(next).await;
+            // External power supply monitoring
+            if let Some((external_power_supply_sysname, initial_power_supply_state)) =
+                std::fs::read_dir("/sys/class/power_supply")
+                    .ok()
+                    .and_then(|dir| {
+                        // Look up the external power supply sysname (e.g. "ACAD") by finding one
+                        // with the type "mains"
+                        dir.flatten().find_map(|entry| {
+                            let type_path = entry.path().canonicalize().ok()?.join("type");
+                            let supply_type = std::fs::read_to_string(type_path).ok()?;
+                            supply_type
+                                .trim()
+                                .eq_ignore_ascii_case("mains")
+                                .then(|| entry.file_name().to_string_lossy().to_string())
+                        })
+                    })
+                    .and_then(|sysname| {
+                        // Look up the initial state of the external power supply
+                        let path = std::path::PathBuf::from("/sys/class/power_supply")
+                            .join(&sysname)
+                            .join("online");
+                        let state = std::fs::read_to_string(&path)
+                            .map_err(|e| {
+                                error!(
+                                    "Could not read external power supply state from {path:?}: {e}"
+                                )
+                            })
+                            .ok()
+                            .map(|s| s.trim() != "0")?;
+                        Some((sysname, state))
+                    })
+            {
+                debug!(
+                    "External power supply plugged in on startup: {}",
+                    initial_power_supply_state
+                );
+                on_external_power_change(initial_power_supply_state).await;
+
+                let handle = tokio::runtime::Handle::current();
+                std::thread::spawn(move || {
+                    'external_power_monitor_thread: {
+                        let mut power_supply_monitor = match udev::MonitorBuilder::new()
+                            .and_then(|m| m.match_subsystem("power_supply"))
+                            .and_then(|m| m.listen())
+                        {
+                            Ok(m) => m,
+                            Err(e) => {
+                                error!("Could not create udev power supply monitor: {e}");
+                                break 'external_power_monitor_thread;
+                            }
+                        };
+
+                        let mut poll = match mio::Poll::new() {
+                            Ok(p) => p,
+                            Err(e) => {
+                                error!("Could not create mio Poll: {e}");
+                                break 'external_power_monitor_thread;
+                            }
+                        };
+
+                        if let Err(e) = poll.registry().register(
+                            &mut power_supply_monitor,
+                            mio::Token(0),
+                            mio::Interest::READABLE,
+                        ) {
+                            error!("Could not register power supply monitor with mio: {e}");
+                            break 'external_power_monitor_thread;
+                        }
+
+                        let mut events = mio::Events::with_capacity(8);
+
+                        let mut last_power_supply_state = initial_power_supply_state;
+                        loop {
+                            match poll.poll(&mut events, None) {
+                                Ok(_) => {}
+                                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                                Err(e) => {
+                                    error!("Power supply monitor poll error: {e}");
+                                    break 'external_power_monitor_thread;
+                                }
+                            }
+
+                            for event in power_supply_monitor.iter() {
+                                if event.event_type() != udev::EventType::Change {
+                                    continue;
+                                }
+                                if event.device().sysname().to_string_lossy()
+                                    != external_power_supply_sysname
+                                {
+                                    continue;
+                                }
+
+                                let Some(current_power_supply_state) = event
+                                    .device()
+                                    .property_value("POWER_SUPPLY_ONLINE")
+                                    .map(|v| v != "0")
+                                else {
+                                    warn!(
+                                        "Power supply change event for external power supply \
+                                         missing POWER_SUPPLY_ONLINE property, skipping..."
+                                    );
+                                    continue;
+                                };
+
+                                if current_power_supply_state != last_power_supply_state {
+                                    last_power_supply_state = current_power_supply_state;
+                                    debug!(
+                                        "External power supply state changed: {}",
+                                        current_power_supply_state
+                                    );
+                                    handle.block_on(on_external_power_change(
+                                        current_power_supply_state,
+                                    ));
+                                }
+                            }
                         }
                     }
-                    sleep(Duration::from_secs(2)).await;
-                }
-            });
+                    error!(
+                        "External power supply monitor exited unexpectedly, changes will no \
+                         longer be detected."
+                    );
+                });
+            } else {
+                warn!("External power supply monitoring unavailable");
+            }
         }
     }
 }

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -18,11 +18,13 @@ pub mod aura_types;
 pub mod error;
 
 use std::future::Future;
+use std::sync::Arc;
 
 use dmi_id::DMIID;
 use futures_util::stream::StreamExt;
 use log::{debug, error, info, warn};
 use logind_zbus::manager::ManagerProxy;
+use rog_platform::power::AsusPower;
 use zbus::object_server::{Interface, SignalEmitter};
 use zbus::proxy::CacheProperties;
 use zbus::zvariant::ObjectPath;
@@ -181,6 +183,108 @@ pub trait ZbusRun {
     }
 }
 
+/// Locate the mains (AC adapter) supply and its `online` attribute. Goes
+/// through `AsusPower` so the monitor watches the same supply `get_online()`
+/// reads.
+fn mains_power_supply() -> Option<(String, std::path::PathBuf)> {
+    let power = AsusPower::new()
+        .map_err(|e| error!("Could not enumerate power supplies: {e}"))
+        .ok()?;
+    match (power.mains_sysname(), power.mains_syspath()) {
+        (Some(sysname), Some(syspath)) => Some((sysname, syspath.join("online"))),
+        _ => {
+            error!(
+                "No power supply with type 'Mains' was found, external power changes will not be \
+                 detected"
+            );
+            None
+        }
+    }
+}
+
+fn read_power_supply_online(path: &std::path::Path) -> Option<bool> {
+    std::fs::read_to_string(path)
+        .map_err(|e| error!("Could not read the external power supply state from {path:?}: {e}"))
+        .ok()
+        .map(|online| online.trim() != "0")
+}
+
+/// Watch the mains power supply for udev change events, publishing the new
+/// `online` state. State is published rather than acted on here so a slow
+/// consumer can never stall the poll loop.
+fn spawn_mains_power_monitor(
+    sysname: String,
+    online_path: std::path::PathBuf,
+    power_state: Arc<tokio::sync::watch::Sender<Option<bool>>>,
+) {
+    std::thread::spawn(move || {
+        let mut monitor = match udev::MonitorBuilder::new()
+            .and_then(|monitor| monitor.match_subsystem("power_supply"))
+            .and_then(|monitor| monitor.listen())
+        {
+            Ok(monitor) => monitor,
+            Err(e) => {
+                error!("Could not create a udev power supply monitor: {e}");
+                return;
+            }
+        };
+
+        let mut poll = match mio::Poll::new() {
+            Ok(poll) => poll,
+            Err(e) => {
+                error!("Could not create a mio poll for the power supply monitor: {e}");
+                return;
+            }
+        };
+
+        if let Err(e) =
+            poll.registry()
+                .register(&mut monitor, mio::Token(0), mio::Interest::READABLE)
+        {
+            error!("Could not register the power supply monitor with mio: {e}");
+            return;
+        }
+
+        let mut events = mio::Events::with_capacity(8);
+        loop {
+            match poll.poll(&mut events, None) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    error!(
+                        "Power supply monitor poll error, external power changes will no longer \
+                         be detected: {e}"
+                    );
+                    return;
+                }
+            }
+
+            for event in monitor.iter() {
+                if event.event_type() != udev::EventType::Change {
+                    continue;
+                }
+                let device = event.device();
+                if device.sysname().to_string_lossy() != sysname {
+                    continue;
+                }
+
+                // A change uevent is not guaranteed to carry the full property set
+                let online = match device.property_value("POWER_SUPPLY_ONLINE") {
+                    Some(value) => Some(value != "0"),
+                    None => {
+                        debug!("Power supply uevent had no POWER_SUPPLY_ONLINE, reading sysfs");
+                        read_power_supply_online(&online_path)
+                    }
+                };
+
+                if online.is_some() && power_state.send(online).is_err() {
+                    return;
+                }
+            }
+        }
+    });
+}
+
 /// Set up a task to run on the async executor
 pub trait CtrlTask {
     fn zbus_path() -> &'static str;
@@ -213,6 +317,10 @@ pub trait CtrlTask {
     ///
     /// The closures can potentially block, so execution time should be the
     /// minimal possible such as save a variable.
+    ///
+    /// `on_lid_change` and `on_external_power_change` are also called once with
+    /// the current state so that the hardware is configured at daemon start,
+    /// not only on the next transition.
     fn create_sys_event_tasks<Fut1, Fut2, Fut3, Fut4, F1, F2, F3, F4>(
         &self,
         mut on_prepare_for_sleep: F1,
@@ -231,15 +339,46 @@ pub trait CtrlTask {
         Fut4: Future<Output = ()> + Send,
     {
         async {
-            let connection = Connection::system()
-                .await
-                .expect("Controller could not create dbus connection");
+            // The system bus can still be coming up during early boot
+            let connection = match Connection::system().await {
+                Ok(connection) => connection,
+                Err(e) => {
+                    error!("Controller could not create dbus connection: {e}");
+                    return;
+                }
+            };
 
-            let logind_manager = ManagerProxy::builder(&connection)
+            let logind_manager = match ManagerProxy::builder(&connection)
                 .cache_properties(CacheProperties::Lazily)
                 .build()
                 .await
-                .expect("Controller could not create ManagerProxy");
+            {
+                Ok(manager) => manager,
+                Err(e) => {
+                    error!("Controller could not create ManagerProxy: {e}");
+                    return;
+                }
+            };
+
+            // Caching is required for the change stream to fire, but it also makes
+            // property reads return cache. A resync must bypass it or it reads back
+            // the same stale value a missed signal left behind.
+            let logind_direct = match ManagerProxy::builder(&connection)
+                .cache_properties(CacheProperties::No)
+                .build()
+                .await
+            {
+                Ok(manager) => Some(manager),
+                Err(e) => {
+                    warn!("Could not create an uncached ManagerProxy, lid state will not resync after resume: {e}");
+                    None
+                }
+            };
+
+            // Bumped after every resume. Change detection below is edge triggered,
+            // so both watchers re-read their source when this ticks.
+            let (resumed, _) = tokio::sync::watch::channel(0u64);
+            let resumed = Arc::new(resumed);
 
             tokio::spawn({
                 let logind_manager = logind_manager.clone();
@@ -258,6 +397,7 @@ pub trait CtrlTask {
 
             tokio::spawn({
                 let logind_manager = logind_manager.clone();
+                let resumed = resumed.clone();
                 async move {
                     if let Ok(mut notif) = logind_manager.receive_prepare_for_sleep().await {
                         while let Some(event) = notif.next().await {
@@ -265,6 +405,9 @@ pub trait CtrlTask {
                             if let Ok(args) = event.args() {
                                 debug!("Doing on_prepare_for_sleep({})", args.start);
                                 on_prepare_for_sleep(args.start).await;
+                                if !args.start {
+                                    resumed.send_modify(|tick| *tick += 1);
+                                }
                             }
                         }
                     }
@@ -273,160 +416,87 @@ pub trait CtrlTask {
 
             tokio::spawn({
                 let logind_manager = logind_manager.clone();
+                let mut resumed = resumed.subscribe();
                 async move {
-                    // 1. Initial Lid State Fetch & Apply at Daemon Startup
+                    // Subscribe before the initial read so a startup change is not lost
+                    let mut stream = logind_manager.receive_lid_closed_changed().await;
+                    let resync = logind_direct.as_ref().unwrap_or(&logind_manager);
+
                     let mut last_lid = match logind_manager.lid_closed().await {
                         Ok(closed) => {
-                            debug!("Initial lid state on startup: {}", closed);
+                            debug!("Initial lid state on startup: {closed}");
                             on_lid_change(closed).await;
-                            closed
+                            Some(closed)
                         }
                         Err(e) => {
-                            warn!("Failed to read initial lid state from logind: {}", e);
-                            false
+                            warn!("Failed to read initial lid state from logind: {e}");
+                            None
                         }
                     };
 
-                    // 2. Subscribe to D-Bus Property Change Stream
-                    let mut stream = logind_manager.receive_lid_closed_changed().await;
+                    loop {
+                        let lid_closed = tokio::select! {
+                            Some(change) = stream.next() => change.get().await,
+                            Ok(()) = resumed.changed() => {
+                                debug!("Re-reading lid state after resume");
+                                resync.lid_closed().await
+                            }
+                            else => break,
+                        };
 
-                    // 3. Process Signals with Event Deduplication
-                    while let Some(change) = stream.next().await {
-                        if let Ok(lid_closed) = change.get().await {
-                            if lid_closed != last_lid {
-                                last_lid = lid_closed;
-                                debug!("Lid state changed: {}", lid_closed);
+                        match lid_closed {
+                            Ok(lid_closed) if last_lid != Some(lid_closed) => {
+                                last_lid = Some(lid_closed);
+                                debug!("Lid state changed: {lid_closed}");
                                 on_lid_change(lid_closed).await;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                // The tracked state is now unknown, let the next read through
+                                last_lid = None;
+                                warn!("Failed to read lid state from logind: {e}");
                             }
                         }
                     }
                 }
             });
 
-            // External power supply monitoring
-            if let Some((external_power_supply_sysname, initial_power_supply_state)) =
-                std::fs::read_dir("/sys/class/power_supply")
-                    .ok()
-                    .and_then(|dir| {
-                        // Look up the external power supply sysname (e.g. "ACAD") by finding one
-                        // with the type "mains"
-                        dir.flatten().find_map(|entry| {
-                            let type_path = entry.path().canonicalize().ok()?.join("type");
-                            let supply_type = std::fs::read_to_string(type_path).ok()?;
-                            supply_type
-                                .trim()
-                                .eq_ignore_ascii_case("mains")
-                                .then(|| entry.file_name().to_string_lossy().to_string())
-                        })
-                    })
-                    .and_then(|sysname| {
-                        // Look up the initial state of the external power supply
-                        let path = std::path::PathBuf::from("/sys/class/power_supply")
-                            .join(&sysname)
-                            .join("online");
-                        let state = std::fs::read_to_string(&path)
-                            .map_err(|e| {
-                                error!(
-                                    "Could not read external power supply state from {path:?}: {e}"
-                                )
-                            })
-                            .ok()
-                            .map(|s| s.trim() != "0")?;
-                        Some((sysname, state))
-                    })
-            {
-                debug!(
-                    "External power supply plugged in on startup: {}",
-                    initial_power_supply_state
-                );
-                on_external_power_change(initial_power_supply_state).await;
+            // logind's OnExternalPower is annotated EmitsChangedSignal=false so it can
+            // only be polled. The kernel emits a udev change event for the mains supply
+            // instead, so watch that. Kept separate from the `aura_manager` monitor,
+            // which belongs to device discovery.
+            if let Some((sysname, online_path)) = mains_power_supply() {
+                // Start the monitor before the initial read so a startup change is not lost
+                let (power_state, mut power_changed) = tokio::sync::watch::channel(None);
+                spawn_mains_power_monitor(sysname, online_path.clone(), Arc::new(power_state));
 
-                let handle = tokio::runtime::Handle::current();
-                std::thread::spawn(move || {
-                    'external_power_monitor_thread: {
-                        let mut power_supply_monitor = match udev::MonitorBuilder::new()
-                            .and_then(|m| m.match_subsystem("power_supply"))
-                            .and_then(|m| m.listen())
-                        {
-                            Ok(m) => m,
-                            Err(e) => {
-                                error!("Could not create udev power supply monitor: {e}");
-                                break 'external_power_monitor_thread;
+                let mut last_power = read_power_supply_online(&online_path);
+                if let Some(online) = last_power {
+                    debug!("External power supply plugged in on startup: {online}");
+                    on_external_power_change(online).await;
+                }
+
+                let mut resumed = resumed.subscribe();
+                tokio::spawn(async move {
+                    loop {
+                        let online = tokio::select! {
+                            Ok(()) = power_changed.changed() => *power_changed.borrow_and_update(),
+                            Ok(()) = resumed.changed() => {
+                                debug!("Re-reading external power state after resume");
+                                read_power_supply_online(&online_path)
                             }
+                            else => break,
                         };
 
-                        let mut poll = match mio::Poll::new() {
-                            Ok(p) => p,
-                            Err(e) => {
-                                error!("Could not create mio Poll: {e}");
-                                break 'external_power_monitor_thread;
-                            }
-                        };
-
-                        if let Err(e) = poll.registry().register(
-                            &mut power_supply_monitor,
-                            mio::Token(0),
-                            mio::Interest::READABLE,
-                        ) {
-                            error!("Could not register power supply monitor with mio: {e}");
-                            break 'external_power_monitor_thread;
-                        }
-
-                        let mut events = mio::Events::with_capacity(8);
-
-                        let mut last_power_supply_state = initial_power_supply_state;
-                        loop {
-                            match poll.poll(&mut events, None) {
-                                Ok(_) => {}
-                                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                                Err(e) => {
-                                    error!("Power supply monitor poll error: {e}");
-                                    break 'external_power_monitor_thread;
-                                }
-                            }
-
-                            for event in power_supply_monitor.iter() {
-                                if event.event_type() != udev::EventType::Change {
-                                    continue;
-                                }
-                                if event.device().sysname().to_string_lossy()
-                                    != external_power_supply_sysname
-                                {
-                                    continue;
-                                }
-
-                                let Some(current_power_supply_state) = event
-                                    .device()
-                                    .property_value("POWER_SUPPLY_ONLINE")
-                                    .map(|v| v != "0")
-                                else {
-                                    warn!(
-                                        "Power supply change event for external power supply \
-                                         missing POWER_SUPPLY_ONLINE property, skipping..."
-                                    );
-                                    continue;
-                                };
-
-                                if current_power_supply_state != last_power_supply_state {
-                                    last_power_supply_state = current_power_supply_state;
-                                    debug!(
-                                        "External power supply state changed: {}",
-                                        current_power_supply_state
-                                    );
-                                    handle.block_on(on_external_power_change(
-                                        current_power_supply_state,
-                                    ));
-                                }
+                        if let Some(online) = online {
+                            if last_power != Some(online) {
+                                last_power = Some(online);
+                                debug!("External power supply state changed: {online}");
+                                on_external_power_change(online).await;
                             }
                         }
                     }
-                    error!(
-                        "External power supply monitor exited unexpectedly, changes will no \
-                         longer be detected."
-                    );
                 });
-            } else {
-                warn!("External power supply monitoring unavailable");
             }
         }
     }

--- a/rog-platform/src/power.rs
+++ b/rog-platform/src/power.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use log::{info, warn};
 
@@ -119,6 +119,23 @@ impl AsusPower {
 
     pub fn has_battery(&self) -> bool {
         !self.battery.as_os_str().is_empty()
+    }
+
+    /// Syspath of the mains (AC adapter) supply that `get_online()` reads,
+    /// e.g. `/sys/devices/.../power_supply/ADP0`
+    pub fn mains_syspath(&self) -> Option<&Path> {
+        (!self.mains.as_os_str().is_empty()).then_some(self.mains.as_path())
+    }
+
+    /// Sysname of the mains supply, e.g. `ADP0`. This is the name udev events
+    /// carry, so it is what a monitor must match against.
+    pub fn mains_sysname(&self) -> Option<String> {
+        Some(
+            self.mains_syspath()?
+                .file_name()?
+                .to_string_lossy()
+                .to_string(),
+        )
     }
 
     pub fn get_battery_cycle_count(&self) -> Result<i32> {


### PR DESCRIPTION
# Description

Instead of polling OnExternalPower and LidClosed every 2 seconds via D-Bus property calls, subscribe to PropertiesChanged signals from logind.

This eliminates constant D-Bus traffic to logind which was causing slowdowns for other logind callers (e.g. podman, busctl GetUser).


<!-- Please include a summary of the changes and the related issue(if applicable). -->
<!-- If this PR introduces a new feature, explain your motivation and the use case. -->

Fixes #235


<details>
<summary> Monitor of the dbus with the old binary </summary>

```
~ ❯ sudo busctl monitor org.freedesktop.login1                                                                                                             6s

Monitoring bus message stream.
‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=31  Timestamp="Thu 2026-07-30 15:02:13.040007 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1612  ReplyCookie=31  Timestamp="Thu 2026-07-30 15:02:13.040299 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN false;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=32  Timestamp="Thu 2026-07-30 15:02:13.043942 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1613  ReplyCookie=32  Timestamp="Thu 2026-07-30 15:02:13.048347 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=33  Timestamp="Thu 2026-07-30 15:02:15.042075 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1614  ReplyCookie=33  Timestamp="Thu 2026-07-30 15:02:15.042399 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN false;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=34  Timestamp="Thu 2026-07-30 15:02:15.049940 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1615  ReplyCookie=34  Timestamp="Thu 2026-07-30 15:02:15.054424 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=115  Timestamp="Thu 2026-07-30 15:02:16.777252 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=ReleaseDevice
  UniqueName=:1.23
  MESSAGE "uu" {
          UINT32 13;
          UINT32 73;
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1616  Timestamp="Thu 2026-07-30 15:02:16.784104 UTC"
  Sender=:1.2  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=PropertiesChanged
  UniqueName=:1.2
  MESSAGE "sa{sv}as" {
          STRING "org.freedesktop.login1.Manager";
          ARRAY "{sv}" {
                  DICT_ENTRY "sv" {
                          STRING "LidClosed";
                          VARIANT "b" {
                                  BOOLEAN true;
                          };
                  };
          };
          ARRAY "s" {
          };
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1617  Timestamp="Thu 2026-07-30 15:02:16.784233 UTC"
  Sender=:1.2  Destination=:1.23  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=PauseDevice
  UniqueName=:1.2
  MESSAGE "uus" {
          UINT32 13;
          UINT32 73;
          STRING "gone";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1618  ReplyCookie=115  Timestamp="Thu 2026-07-30 15:02:16.784288 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "" {
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=116  Timestamp="Thu 2026-07-30 15:02:16.784980 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Peer  Member=Ping
  UniqueName=:1.23
  MESSAGE "" {
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1619  ReplyCookie=116  Timestamp="Thu 2026-07-30 15:02:16.790838 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "" {
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=35  Timestamp="Thu 2026-07-30 15:02:17.043613 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1620  ReplyCookie=35  Timestamp="Thu 2026-07-30 15:02:17.044036 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=36  Timestamp="Thu 2026-07-30 15:02:17.055613 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1621  ReplyCookie=36  Timestamp="Thu 2026-07-30 15:02:17.059770 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=37  Timestamp="Thu 2026-07-30 15:02:19.046166 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1622  ReplyCookie=37  Timestamp="Thu 2026-07-30 15:02:19.046527 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=38  Timestamp="Thu 2026-07-30 15:02:19.061911 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1623  ReplyCookie=38  Timestamp="Thu 2026-07-30 15:02:19.065663 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=117  Timestamp="Thu 2026-07-30 15:02:20.137307 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=TakeDevice
  UniqueName=:1.23
  MESSAGE "uu" {
          UINT32 13;
          UINT32 73;
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1624  Timestamp="Thu 2026-07-30 15:02:20.137814 UTC"
  Sender=:1.2  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=PropertiesChanged
  UniqueName=:1.2
  MESSAGE "sa{sv}as" {
          STRING "org.freedesktop.login1.Manager";
          ARRAY "{sv}" {
                  DICT_ENTRY "sv" {
                          STRING "LidClosed";
                          VARIANT "b" {
                                  BOOLEAN false;
                          };
                  };
          };
          ARRAY "s" {
          };
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1625  ReplyCookie=117  Timestamp="Thu 2026-07-30 15:02:20.138319 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "hb" {
          UNIX_FD 5;
          BOOLEAN false;
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=39  Timestamp="Thu 2026-07-30 15:02:21.048979 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1626  ReplyCookie=39  Timestamp="Thu 2026-07-30 15:02:21.049466 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN false;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=40  Timestamp="Thu 2026-07-30 15:02:21.067058 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1627  ReplyCookie=40  Timestamp="Thu 2026-07-30 15:02:21.071663 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=41  Timestamp="Thu 2026-07-30 15:02:23.051181 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "LidClosed";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1628  ReplyCookie=41  Timestamp="Thu 2026-07-30 15:02:23.051486 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN false;
          };
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=42  Timestamp="Thu 2026-07-30 15:02:23.073109 UTC"
  Sender=:1.364  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=Get
  UniqueName=:1.364
  MESSAGE "ss" {
          STRING "org.freedesktop.login1.Manager";
          STRING "OnExternalPower";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1629  ReplyCookie=42  Timestamp="Thu 2026-07-30 15:02:23.077468 UTC"
  Sender=:1.2  Destination=:1.364
  UniqueName=:1.2
  MESSAGE "v" {
          VARIANT "b" {
                  BOOLEAN true;
          };
  };
```

</details>

<details>
<summary> Logs of the old binary </summary>

```
asusctl HEAD[$!+]❯ sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=debug target/release/asusd               10s❄️  🦀
Starting asusd daemon...
[INFO  asusd]        daemon v6.3.11
[INFO  asusd]     rog-anime v6.3.11
[INFO  asusd]     rog-slash v6.3.11
[INFO  asusd]      rog-aura v6.3.11
[INFO  asusd]  rog-profiles v6.3.11
[INFO  asusd] rog-platform v6.3.11
[INFO  asusd] Product family: ROG Zephyrus G16
[INFO  asusd] Board name: GA605WV
[INFO  config_traits] Parsed RON for "asusd::config::Config"
[INFO  rog_platform::platform] Found platform support at "asus-nb-wmi"
[INFO  rog_platform::power] Power: Checking "/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0A:00/power_supply/BAT1"
[INFO  rog_platform::power] Found a battery
[INFO  rog_platform::power] Checking battery attributes
[INFO  rog_platform::power] Found battery power at "BAT1", matched charge_control_end_threshold. Current level: "90"
[INFO  rog_platform::power] Power: Checking "/sys/devices/pci0000:00/0000:00:08.3/0000:68:00.4/usb7/7-1/7-1.4/7-1.4.2/7-1.4.2:1.1/0003:046D:C082.001A/power_supply/hidpp_battery_2"
[INFO  rog_platform::power] Found a battery
[INFO  rog_platform::power] Power: Checking "/sys/devices/platform/ACPI0003:00/power_supply/ACAD"
[INFO  rog_platform::power] Found mains power at "ACAD"
[INFO  rog_platform::power] Power: Checking "/sys/devices/virtual/misc/uhid/0005:004C:026C.000B/power_supply/hid-c4:14:11:12:18:1d-battery-144"
[INFO  rog_platform::power] Found a battery
[INFO  asusd::asus_armoury] Reloading nv_dynamic_boost
[INFO  asusd::asus_armoury] No saved value for attribute nv_dynamic_boost: skipping.
[INFO  asusd::asus_armoury] Reloading nv_base_tgp
[INFO  asusd::asus_armoury] Reload called on read-only attribute nv_base_tgp: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute nv_base_tgp: skipping.
[INFO  asusd::asus_armoury] Reloading ppt_pl3_fppt
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl3_fppt: skipping.
[INFO  asusd::asus_armoury] Reloading charge_mode
[INFO  asusd::asus_armoury] Reload called on firmware attribute charge_mode
[INFO  asusd::asus_armoury] No saved value for attribute charge_mode: skipping.
[INFO  asusd::asus_armoury] Reloading nv_temp_target
[INFO  asusd::asus_armoury] No saved value for attribute nv_temp_target: skipping.
[INFO  asusd::asus_armoury] Reloading nv_tgp
[INFO  asusd::asus_armoury] No saved value for attribute nv_tgp: skipping.
[INFO  asusd::asus_armoury] Reloading panel_overdrive
[INFO  asusd::asus_armoury] Reload called on firmware attribute panel_overdrive
[INFO  asusd::asus_armoury] Applying value Integer(0) to attribute panel_overdrive
[INFO  asusd::asus_armoury] Restored asus-armoury setting panel_overdrive to Integer(0)
[INFO  asusd::asus_armoury] Reloading ppt_pl1_spl
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl1_spl: skipping.
[INFO  asusd::asus_armoury] Reloading ppt_pl2_sppt
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl2_sppt: skipping.
[INFO  asusd::asus_armoury] Reloading gpu_mux_mode
[INFO  asusd::asus_armoury] Reload called on GPU attribute gpu_mux_mode: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute gpu_mux_mode: skipping.
[INFO  asusd::asus_armoury] Reloading dgpu_disable
[INFO  asusd::asus_armoury] Reload called on GPU attribute dgpu_disable: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute dgpu_disable: skipping.
[INFO  asusd::asus_armoury] Reloading boot_sound
[INFO  asusd::asus_armoury] Reload called on firmware attribute boot_sound
[INFO  asusd::asus_armoury] No saved value for attribute boot_sound: skipping.
[INFO  asusd] attribute on zbus initialized
[INFO  rog_platform::platform] Found platform support at "asus-nb-wmi"
[INFO  asusd::ctrl_fancurves] Device has profile control available
[INFO  asusd::ctrl_fancurves] Device has fan curves available
[INFO  config_traits] Parsed RON for "asusd::ctrl_fancurves::FanCurveConfig"
[INFO  asusd::ctrl_fancurves] Fan curves previously stored, loading...
[INFO  config_traits] Parsed RON for "asusd::ctrl_fancurves::FanCurveConfig"
[INFO  asusd] FanCurves: found supported fancurves
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: CPU, pwm: [2, 12, 38, 56, 68, 73, 104, 104], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: GPU, pwm: [2, 7, 28, 40, 58, 71, 96, 96], temp: [54, 58, 62, 65, 68, 71, 74, 74], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: MID, pwm: [2, 20, 20, 38, 86, 142, 142, 142], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[INFO  asusd] FanCurves: initialized
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:03.1/0000:65:00.0/backlight/nvidia_0"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:08.1/0000:66:00.0/drm/card1/card1-eDP-1/amdgpu_bl1"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:03.1/0000:65:00.0/backlight/nvidia_0"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:08.1/0000:66:00.0/drm/card1/card1-eDP-1/amdgpu_bl1"
[ERROR asusd] Backlight: Missing functionality: No backlights found
[INFO  rog_platform::cpu] Found CPU support at "cpu0", checking supported items
[INFO  rog_platform::cpu] cpufreq/scaling_available_governors: "performance powersave"
[INFO  rog_platform::cpu] cpufreq/scaling_governor: "powersave"
[INFO  rog_platform::cpu] cpufreq/energy_performance_available_preferences: "default performance balance_performance balance_power power custom "
[INFO  rog_platform::cpu] cpufreq/energy_performance_preference: "power"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu0"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu1"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu10"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu11"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu12"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu13"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu14"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu15"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu16"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu17"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu18"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu19"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu2"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu20"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu21"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu22"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu23"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu3"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu4"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu5"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu6"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu7"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu8"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu9"
[INFO  asusd] CtrlPlatform: initialized
[INFO  asusd::ctrl_platform] Starting inotify watch for asusd config file
[INFO  asusd::ctrl_platform] Begin Platform settings restore
[INFO  asusd::ctrl_platform] reloading charge_control_end_threshold to 90
[DEBUG asusd::ctrl_platform] Setting LowPower before EPP
[WARN  asusd::ctrl_platform] Failed to set platform profile LowPower on AC/BAT change: platform_profile Operation not supported (os error 95)
[INFO  asusd] CtrlPlatform: tasks started
[DEBUG asusd::aura_manager] Testing device "19b6"
[DEBUG asusd::aura_types] Testing for HIDRAW Slash
[INFO  asusd::aura_types] Found slash type GA605_2024: 19b6
[INFO  config_traits] Parsed RON for "asusd::aura_slash::config::SlashConfig"
[DEBUG asusd::aura_slash::trait_impls] reloading slash settings
[DEBUG asusd::aura_types] Testing for laptop aura
[INFO  asusd::aura_types] Found laptop aura type "19b6"
[INFO  rog_platform::keyboard_led] Found keyboard LED controls at "asus::kbd_backlight"
[INFO  asusd::aura_types] Found sysfs backlight control
[INFO  asusd::aura_laptop::config] Setting up AuraConfig for "19b6"
[INFO  rog_aura::aura_detection] Loaded bundled LED support data (embedded)
[INFO  rog_aura::aura_detection] Matched to GA605W
[DEBUG asusd::aura_laptop::config] creating default for Static
[DEBUG asusd::aura_laptop::config] creating default for Breathe
[DEBUG asusd::aura_laptop::config] creating default for RainbowCycle
[DEBUG asusd::aura_laptop::config] creating default for RainbowWave
[DEBUG asusd::aura_laptop::config] creating default for Pulse
[INFO  config_traits] Parsed RON for "asusd::aura_laptop::config::AuraConfig"
[DEBUG asusd::aura_laptop::trait_impls] reloading keyboard mode
[DEBUG asusd::aura_laptop::trait_impls] reloading power states
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 17ef
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 17ef
[DEBUG asusd::aura_types] Testing for USB AniMe
[INFO  asusd::aura_types] No Anime Matrix capable laptop found
[INFO  asusd::aura_manager] Tested device was not AniMe Matrix
[INFO  asusd::aura_manager] Found 2 valid devices on startup
[INFO  asusd] DeviceManager initialized
[INFO  asusd::ctrl_xgm_led] XG Mobile LED not found: Missing functionality: CledDevice::new_from_pattern(): no LED containing 'asus:xgm' found
[INFO  asusd] XG Mobile LED: not present
[INFO  asusd] Startup success on dbus name xyz.ljones.Asusd: begining dbus server loop
```

</details>

<details>
<summary> Monitor of the dbus with the new binary </summary>

```
~ ❯ sudo busctl monitor org.freedesktop.login1

Monitoring bus message stream.
‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=118  Timestamp="Thu 2026-07-30 15:06:31.265317 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=ReleaseDevice
  UniqueName=:1.23
  MESSAGE "uu" {
          UINT32 13;
          UINT32 73;
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1772  Timestamp="Thu 2026-07-30 15:06:31.271987 UTC"
  Sender=:1.2  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=PropertiesChanged
  UniqueName=:1.2
  MESSAGE "sa{sv}as" {
          STRING "org.freedesktop.login1.Manager";
          ARRAY "{sv}" {
                  DICT_ENTRY "sv" {
                          STRING "LidClosed";
                          VARIANT "b" {
                                  BOOLEAN true;
                          };
                  };
          };
          ARRAY "s" {
          };
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1773  Timestamp="Thu 2026-07-30 15:06:31.272074 UTC"
  Sender=:1.2  Destination=:1.23  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=PauseDevice
  UniqueName=:1.2
  MESSAGE "uus" {
          UINT32 13;
          UINT32 73;
          STRING "gone";
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1774  ReplyCookie=118  Timestamp="Thu 2026-07-30 15:06:31.272363 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "" {
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=119  Timestamp="Thu 2026-07-30 15:06:31.273023 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Peer  Member=Ping
  UniqueName=:1.23
  MESSAGE "" {
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1775  ReplyCookie=119  Timestamp="Thu 2026-07-30 15:06:31.278101 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "" {
  };

‣ Type=method_call  Endian=l  Flags=0  Version=1 Cookie=120  Timestamp="Thu 2026-07-30 15:06:38.467545 UTC"
  Sender=:1.23  Destination=org.freedesktop.login1  Path=/org/freedesktop/login1/session/_31  Interface=org.freedesktop.login1.Session  Member=TakeDevice
  UniqueName=:1.23
  MESSAGE "uu" {
          UINT32 13;
          UINT32 73;
  };

‣ Type=signal  Endian=l  Flags=1  Version=1 Cookie=1776  Timestamp="Thu 2026-07-30 15:06:38.467892 UTC"
  Sender=:1.2  Path=/org/freedesktop/login1  Interface=org.freedesktop.DBus.Properties  Member=PropertiesChanged
  UniqueName=:1.2
  MESSAGE "sa{sv}as" {
          STRING "org.freedesktop.login1.Manager";
          ARRAY "{sv}" {
                  DICT_ENTRY "sv" {
                          STRING "LidClosed";
                          VARIANT "b" {
                                  BOOLEAN false;
                          };
                  };
          };
          ARRAY "s" {
          };
  };

‣ Type=method_return  Endian=l  Flags=1  Version=1 Cookie=1777  ReplyCookie=120  Timestamp="Thu 2026-07-30 15:06:38.468406 UTC"
  Sender=:1.2  Destination=:1.23
  UniqueName=:1.2
  MESSAGE "hb" {
          UNIX_FD 5;
          BOOLEAN false;
  };
```

</details>

<details>
<summary> Logs of the new binary </summary>

```
asusctl reduce-logind-spam[$!+]❯ sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH RUST_LOG=debug target/release/asusd    ❄️  🦀
Starting asusd daemon...
[INFO  asusd]        daemon v6.3.11
[INFO  asusd]     rog-anime v6.3.11
[INFO  asusd]     rog-slash v6.3.11
[INFO  asusd]      rog-aura v6.3.11
[INFO  asusd]  rog-profiles v6.3.11
[INFO  asusd] rog-platform v6.3.11
[INFO  asusd] Product family: ROG Zephyrus G16
[INFO  asusd] Board name: GA605WV
[INFO  config_traits] Parsed RON for "asusd::config::Config"
[INFO  rog_platform::platform] Found platform support at "asus-nb-wmi"
[INFO  rog_platform::power] Power: Checking "/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0A:00/power_supply/BAT1"
[INFO  rog_platform::power] Found a battery
[INFO  rog_platform::power] Checking battery attributes
[INFO  rog_platform::power] Found battery power at "BAT1", matched charge_control_end_threshold. Current level: "90"
[INFO  rog_platform::power] Power: Checking "/sys/devices/pci0000:00/0000:00:08.3/0000:68:00.4/usb7/7-1/7-1.4/7-1.4.2/7-1.4.2:1.1/0003:046D:C082.001A/power_supply/hidpp_battery_2"
[INFO  rog_platform::power] Found a battery
[INFO  rog_platform::power] Power: Checking "/sys/devices/platform/ACPI0003:00/power_supply/ACAD"
[INFO  rog_platform::power] Found mains power at "ACAD"
[INFO  rog_platform::power] Power: Checking "/sys/devices/virtual/misc/uhid/0005:004C:026C.000B/power_supply/hid-c4:14:11:12:18:1d-battery-144"
[INFO  rog_platform::power] Found a battery
[INFO  asusd::asus_armoury] Reloading nv_dynamic_boost
[INFO  asusd::asus_armoury] No saved value for attribute nv_dynamic_boost: skipping.
[INFO  asusd::asus_armoury] Reloading nv_base_tgp
[INFO  asusd::asus_armoury] Reload called on read-only attribute nv_base_tgp: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute nv_base_tgp: skipping.
[INFO  asusd::asus_armoury] Reloading ppt_pl3_fppt
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl3_fppt: skipping.
[INFO  asusd::asus_armoury] Reloading charge_mode
[INFO  asusd::asus_armoury] Reload called on firmware attribute charge_mode
[INFO  asusd::asus_armoury] No saved value for attribute charge_mode: skipping.
[INFO  asusd::asus_armoury] Reloading nv_temp_target
[INFO  asusd::asus_armoury] No saved value for attribute nv_temp_target: skipping.
[INFO  asusd::asus_armoury] Reloading nv_tgp
[INFO  asusd::asus_armoury] No saved value for attribute nv_tgp: skipping.
[INFO  asusd::asus_armoury] Reloading panel_overdrive
[INFO  asusd::asus_armoury] Reload called on firmware attribute panel_overdrive
[INFO  asusd::asus_armoury] Applying value Integer(0) to attribute panel_overdrive
[INFO  asusd::asus_armoury] Restored asus-armoury setting panel_overdrive to Integer(0)
[INFO  asusd::asus_armoury] Reloading ppt_pl1_spl
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl1_spl: skipping.
[INFO  asusd::asus_armoury] Reloading ppt_pl2_sppt
[INFO  asusd::asus_armoury] No saved value for attribute ppt_pl2_sppt: skipping.
[INFO  asusd::asus_armoury] Reloading gpu_mux_mode
[INFO  asusd::asus_armoury] Reload called on GPU attribute gpu_mux_mode: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute gpu_mux_mode: skipping.
[INFO  asusd::asus_armoury] Reloading dgpu_disable
[INFO  asusd::asus_armoury] Reload called on GPU attribute dgpu_disable: doing nothing
[INFO  asusd::asus_armoury] No saved value for attribute dgpu_disable: skipping.
[INFO  asusd::asus_armoury] Reloading boot_sound
[INFO  asusd::asus_armoury] Reload called on firmware attribute boot_sound
[INFO  asusd::asus_armoury] No saved value for attribute boot_sound: skipping.
[INFO  asusd] attribute on zbus initialized
[INFO  rog_platform::platform] Found platform support at "asus-nb-wmi"
[INFO  asusd::ctrl_fancurves] Device has profile control available
[INFO  asusd::ctrl_fancurves] Device has fan curves available
[INFO  config_traits] Parsed RON for "asusd::ctrl_fancurves::FanCurveConfig"
[INFO  asusd::ctrl_fancurves] Fan curves previously stored, loading...
[INFO  config_traits] Parsed RON for "asusd::ctrl_fancurves::FanCurveConfig"
[INFO  asusd] FanCurves: found supported fancurves
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: CPU, pwm: [2, 12, 38, 56, 68, 73, 104, 104], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: GPU, pwm: [2, 7, 28, 40, 58, 71, 96, 96], temp: [54, 58, 62, 65, 68, 71, 74, 74], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: MID, pwm: [2, 20, 20, 38, 86, 142, 142, 142], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[INFO  asusd] FanCurves: initialized
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:03.1/0000:65:00.0/backlight/nvidia_0"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:08.1/0000:66:00.0/drm/card1/card1-eDP-1/amdgpu_bl1"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:03.1/0000:65:00.0/backlight/nvidia_0"
[INFO  rog_platform::backlight] Backlight: Checking "/sys/devices/pci0000:00/0000:00:08.1/0000:66:00.0/drm/card1/card1-eDP-1/amdgpu_bl1"
[ERROR asusd] Backlight: Missing functionality: No backlights found
[INFO  rog_platform::cpu] Found CPU support at "cpu0", checking supported items
[INFO  rog_platform::cpu] cpufreq/scaling_available_governors: "performance powersave"
[INFO  rog_platform::cpu] cpufreq/scaling_governor: "powersave"
[INFO  rog_platform::cpu] cpufreq/energy_performance_available_preferences: "default performance balance_performance balance_power power custom "
[INFO  rog_platform::cpu] cpufreq/energy_performance_preference: "power"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu0"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu1"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu10"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu11"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu12"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu13"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu14"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu15"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu16"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu17"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu18"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu19"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu2"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu20"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu21"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu22"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu23"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu3"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu4"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu5"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu6"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu7"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu8"
[INFO  rog_platform::cpu] Adding: "/sys/devices/system/cpu/cpu9"
[INFO  asusd] CtrlPlatform: initialized
[INFO  asusd::ctrl_platform] Begin Platform settings restore
[INFO  asusd::ctrl_platform] Starting inotify watch for asusd config file
[INFO  asusd::ctrl_platform] reloading charge_control_end_threshold to 90
[DEBUG asusd::ctrl_platform] Setting LowPower before EPP
[WARN  asusd::ctrl_platform] Failed to set platform profile LowPower on AC/BAT change: platform_profile Operation not supported (os error 95)
[DEBUG asusd] Doing on_external_power(true)
[DEBUG asusd] Doing on_lid_change(false)
[DEBUG asusd::ctrl_platform] Setting LowPower before EPP
[WARN  asusd::ctrl_platform] Failed to set platform profile LowPower on AC/BAT change: platform_profile Operation not supported (os error 95)
[INFO  asusd] CtrlPlatform: tasks started
[DEBUG asusd::aura_manager] Testing device "19b6"
[DEBUG asusd::aura_types] Testing for HIDRAW Slash
[INFO  asusd::aura_types] Found slash type GA605_2024: 19b6
[INFO  config_traits] Parsed RON for "asusd::aura_slash::config::SlashConfig"
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: CPU, pwm: [2, 12, 38, 56, 68, 73, 104, 104], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: GPU, pwm: [2, 7, 28, 40, 58, 71, 96, 96], temp: [54, 58, 62, 65, 68, 71, 74, 74], enabled: false }
[DEBUG rog_profiles] write_profile_curve_to_platform: writing profile:(quiet), CurveData { fan: MID, pwm: [2, 20, 20, 38, 86, 142, 142, 142], temp: [52, 60, 71, 76, 78, 80, 82, 82], enabled: false }
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[INFO  asusd::asus_armoury] Restored armoury setting for panel_overdrive = 0
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[DEBUG asusd::asus_armoury] Tuning group is not enabled, skipping
[DEBUG asusd::asus_armoury] panel_overdrive changed
[DEBUG asusd::asus_armoury] panel_overdrive changed
[DEBUG asusd::asus_armoury] panel_overdrive changed
[DEBUG asusd::asus_armoury] panel_overdrive changed
[DEBUG asusd::aura_slash::trait_impls] reloading slash settings
[DEBUG asusd::aura_types] Testing for laptop aura
[INFO  asusd::aura_types] Found laptop aura type "19b6"
[INFO  rog_platform::keyboard_led] Found keyboard LED controls at "asus::kbd_backlight"
[INFO  asusd::aura_types] Found sysfs backlight control
[INFO  asusd::aura_laptop::config] Setting up AuraConfig for "19b6"
[INFO  rog_aura::aura_detection] Loaded bundled LED support data (embedded)
[INFO  rog_aura::aura_detection] Matched to GA605W
[DEBUG asusd::aura_laptop::config] creating default for Static
[DEBUG asusd::aura_laptop::config] creating default for Breathe
[DEBUG asusd::aura_laptop::config] creating default for RainbowCycle
[DEBUG asusd::aura_laptop::config] creating default for RainbowWave
[DEBUG asusd::aura_laptop::config] creating default for Pulse
[INFO  config_traits] Parsed RON for "asusd::aura_laptop::config::AuraConfig"
[DEBUG asusd::aura_laptop::trait_impls] reloading keyboard mode
[DEBUG asusd::aura_laptop::trait_impls] reloading power states
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 17ef
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 046d
[DEBUG asusd::aura_manager] Not ASUS vendor ID: 17ef
[DEBUG asusd::aura_types] Testing for USB AniMe
[INFO  asusd::aura_types] No Anime Matrix capable laptop found
[INFO  asusd::aura_manager] Tested device was not AniMe Matrix
[INFO  asusd::aura_manager] Found 2 valid devices on startup
[INFO  asusd] DeviceManager initialized
[INFO  asusd::ctrl_xgm_led] XG Mobile LED not found: Missing functionality: CledDevice::new_from_pattern(): no LED containing 'asus:xgm' found
[INFO  asusd] XG Mobile LED: not present
[INFO  asusd] Startup success on dbus name xyz.ljones.Asusd: begining dbus server loop
[DEBUG asusd] Doing on_lid_change(true)
[DEBUG asusd] Doing on_lid_change(false)
```

</details>

Note the time separation of the events in the monitor for the new binary, the timestamps correspond to when I closed and opened the lid.

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Zephyrus G16 GA605WV_GA605WV (1.0)
- **Linux Distribution:** NixOS 25.11 (Xantusia) x86_64
- **Kernel Version:** Linux 7.1.5-cachyos

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`) 
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
