### PR TITLE
feat(dialpad): add ASUS DialPad hardware controller and CLI subcommands

### DIFF
--- a/asusctl/src/cli_opts.rs
+++ b/asusctl/src/cli_opts.rs
@@ -30,6 +30,7 @@ pub enum CliCommand {
     Battery(BatteryCommand),
     Info(InfoCommand),
     XgmLed(XgmLedCommand),
+    Dialpad(DialpadCommand),
 }
 
 impl Default for CliCommand {
@@ -364,5 +365,50 @@ pub struct XgmLedGetCommand {}
 )]
 pub struct XgmLedSetCommand {
     #[argh(positional, description = "zero for off, one for on")]
+    pub value: u8,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "dialpad", description = "ASUS DialPad control")]
+pub struct DialpadCommand {
+    #[argh(subcommand)]
+    pub command: DialpadSubCommand,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
+pub enum DialpadSubCommand {
+    Get(DialpadGetCommand),
+    On(DialpadOnCommand),
+    Off(DialpadOffCommand),
+    Brightness(DialpadSetBrightnessCommand),
+}
+
+impl Default for DialpadSubCommand {
+    fn default() -> Self {
+        DialpadSubCommand::Get(DialpadGetCommand::default())
+    }
+}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "get", description = "get current DialPad status")]
+pub struct DialpadGetCommand {}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "on", description = "turn DialPad on")]
+pub struct DialpadOnCommand {}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "off", description = "turn DialPad off")]
+pub struct DialpadOffCommand {}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "brightness",
+    description = "set DialPad brightness (0-255)"
+)]
+pub struct DialpadSetBrightnessCommand {
+    #[argh(positional, description = "brightness level (0-255)")]
     pub value: u8,
 }

--- a/asusctl/src/dialpad_cli.rs
+++ b/asusctl/src/dialpad_cli.rs
@@ -1,0 +1,36 @@
+use crate::cli_opts::{DialpadCommand, DialpadSubCommand};
+use log::info;
+use rog_dbus::zbus_dialpad::DialpadProxyBlocking;
+
+pub fn handle_dialpad(cmd: &DialpadCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let proxy = DialpadProxyBlocking::new(&zbus::blocking::Connection::system()?)
+        .map_err(|e| format!("Failed to connect to DialPad interface: {e}"))?;
+
+    match &cmd.command {
+        DialpadSubCommand::Get(_) => {
+            let supported = proxy.supported().unwrap_or(true);
+            let enabled = proxy.enabled()?;
+            let brightness = proxy.brightness()?;
+            info!(
+                "DialPad Supported: {}",
+                if supported { "YES" } else { "NO" }
+            );
+            info!("DialPad Enabled: {}", if enabled { "YES" } else { "NO" });
+            info!("DialPad Brightness: {brightness}");
+        }
+        DialpadSubCommand::On(_) => {
+            proxy.set_enabled(true)?;
+            info!("DialPad set to enabled");
+        }
+        DialpadSubCommand::Off(_) => {
+            proxy.set_enabled(false)?;
+            info!("DialPad set to disabled");
+        }
+        DialpadSubCommand::Brightness(cmd) => {
+            proxy.set_brightness(cmd.value)?;
+            info!("DialPad brightness set to {}", cmd.value);
+        }
+    }
+
+    Ok(())
+}

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -36,6 +36,7 @@ use crate::slash_cli::{
 mod anime_cli;
 mod aura_cli;
 mod cli_opts;
+mod dialpad_cli;
 mod fan_curve_cli;
 mod scsi_cli;
 mod slash_cli;
@@ -208,6 +209,7 @@ fn do_parsed(
         CliCommand::Backlight(cmd) => handle_backlight(cmd)?,
         CliCommand::Battery(cmd) => handle_battery(cmd, &conn)?,
         CliCommand::XgmLed(cmd) => xgm_led_cli::handle_xgm_led(&cmd.command)?,
+        CliCommand::Dialpad(cmd) => dialpad_cli::handle_dialpad(cmd)?,
         CliCommand::Info(info_opt) => {
             handle_info(info_opt, supported_interfaces, supported_properties)?
         }

--- a/asusd/src/config.rs
+++ b/asusd/src/config.rs
@@ -63,6 +63,12 @@ pub struct Config {
     /// Some(true) = ON. Re-applied when the device appears.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub xgm_led_enabled: Option<bool>,
+    /// Persisted DialPad enabled state
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dialpad_enabled: Option<bool>,
+    /// Persisted DialPad brightness state
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dialpad_brightness: Option<u8>,
     /// Temporary state for AC/Batt
     #[serde(skip)]
     pub last_power_plugged: u8,
@@ -119,6 +125,8 @@ impl Default for Config {
             screenpad_gamma: Default::default(),
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
         }
     }
 }
@@ -196,6 +204,8 @@ impl From<Config611> for Config {
             screenpad_gamma: None,
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
         };
 
         config.ac_profile_tunings = c.ac_profile_tunings;
@@ -269,6 +279,8 @@ impl From<Config601> for Config {
             screenpad_gamma: None,
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
         }
     }
 }

--- a/asusd/src/ctrl_dialpad.rs
+++ b/asusd/src/ctrl_dialpad.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+
+use config_traits::StdConfig;
+use log::{error, info, warn};
+use rog_platform::dialpad::Dialpad;
+use tokio::sync::Mutex;
+use zbus::fdo::Error as FdoErr;
+use zbus::{interface, Connection};
+
+use crate::config::Config;
+use crate::error::RogError;
+
+pub const DIALPAD_ZBUS_PATH: &str = "/xyz/ljones/Dialpad";
+
+/// Controller for the ASUS Touchpad DialPad LED and hardware state.
+#[derive(Clone)]
+pub struct CtrlDialpad {
+    dialpad: Dialpad,
+    config: Arc<Mutex<Config>>,
+}
+
+impl CtrlDialpad {
+    pub async fn try_new(config: Arc<Mutex<Config>>) -> Result<Option<Self>, RogError> {
+        match Dialpad::new() {
+            Ok(dialpad) => {
+                info!("Found ASUS DialPad hardware device");
+                let ctrl = Self { dialpad, config };
+
+                let c = ctrl.config.lock().await;
+                if let Err(e) = ctrl.apply_saved_state(&c) {
+                    error!("Failed to apply saved DialPad state on startup: {e}");
+                }
+                drop(c);
+
+                Ok(Some(ctrl))
+            }
+            Err(e) => {
+                info!("ASUS DialPad device not found: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Helper to compute the target brightness based on saved config and max hardware brightness.
+    fn desired_brightness(&self, config: &Config) -> u8 {
+        let max_b = self.dialpad.get_max_brightness().unwrap_or(255);
+        config.dialpad_brightness.unwrap_or(max_b).min(max_b)
+    }
+
+    /// Helper to apply saved config state to hardware (used by try_new and reload).
+    ///
+    /// LED brightness is the primary control mechanism. WMI ACPI state toggle is attempted,
+    /// but WMI write failures are treated as non-fatal warnings since not all hardware revisions
+    /// require or support WMI signaling.
+    fn apply_saved_state(&self, config: &Config) -> Result<(), RogError> {
+        let enabled = config.dialpad_enabled.unwrap_or(true);
+        let target_brightness = if enabled {
+            self.desired_brightness(config)
+        } else {
+            0
+        };
+
+        self.dialpad
+            .set_brightness(target_brightness)
+            .map_err(RogError::Platform)?;
+
+        if let Err(e) = self.dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+        Ok(())
+    }
+
+    /// Check if the DialPad is currently enabled (inferred via LED brightness > 0).
+    fn is_enabled(&self) -> bool {
+        self.dialpad
+            .get_brightness()
+            .map(|v| v > 0)
+            .unwrap_or(false)
+    }
+
+    async fn set_enabled_inner(&self, enabled: bool) -> Result<(), FdoErr> {
+        let mut config = self.config.lock().await;
+        config.dialpad_enabled = Some(enabled);
+
+        let brightness_to_set = if enabled {
+            self.desired_brightness(&config)
+        } else {
+            0
+        };
+
+        self.dialpad
+            .set_brightness(brightness_to_set)
+            .map_err(|e| {
+                warn!("Failed to set DialPad brightness: {e}");
+                FdoErr::Failed(format!("Failed to set DialPad brightness: {e}"))
+            })?;
+
+        if let Err(e) = self.dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+
+        config.write();
+        Ok(())
+    }
+
+    fn get_brightness_inner(&self) -> u8 {
+        self.dialpad.get_brightness().unwrap_or(0)
+    }
+
+    async fn set_brightness_inner(&self, value: u8) -> Result<(), FdoErr> {
+        let max_b = self.dialpad.get_max_brightness().unwrap_or(255);
+        let clamped_value = value.min(max_b);
+
+        self.dialpad.set_brightness(clamped_value).map_err(|e| {
+            warn!("Failed to set DialPad brightness: {e}");
+            FdoErr::Failed(format!("Failed to set DialPad brightness: {e}"))
+        })?;
+
+        let enabled = clamped_value > 0;
+        if let Err(e) = self.dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+
+        let mut config = self.config.lock().await;
+        config.dialpad_brightness = Some(clamped_value);
+        config.dialpad_enabled = Some(enabled);
+        config.write();
+        Ok(())
+    }
+}
+
+#[interface(name = "xyz.ljones.Dialpad")]
+impl CtrlDialpad {
+    #[zbus(property)]
+    async fn enabled(&self) -> Result<bool, FdoErr> {
+        Ok(self.is_enabled())
+    }
+
+    #[zbus(property)]
+    async fn set_enabled(&self, enabled: bool) -> Result<(), zbus::Error> {
+        self.set_enabled_inner(enabled).await.map_err(Into::into)
+    }
+
+    #[zbus(property)]
+    async fn brightness(&self) -> Result<u8, FdoErr> {
+        Ok(self.get_brightness_inner())
+    }
+
+    #[zbus(property)]
+    async fn set_brightness(&self, value: u8) -> Result<(), zbus::Error> {
+        self.set_brightness_inner(value).await.map_err(Into::into)
+    }
+
+    #[zbus(property)]
+    async fn supported(&self) -> Result<bool, FdoErr> {
+        Ok(true)
+    }
+}
+
+impl crate::ZbusRun for CtrlDialpad {
+    async fn add_to_server(self, server: &mut Connection) {
+        Self::add_to_server_helper(self, DIALPAD_ZBUS_PATH, server).await;
+    }
+}
+
+impl crate::Reloadable for CtrlDialpad {
+    async fn reload(&mut self) -> Result<(), RogError> {
+        info!("Reloading DialPad settings");
+        let lock = self.config.lock().await;
+        self.apply_saved_state(&lock)
+    }
+}

--- a/asusd/src/daemon.rs
+++ b/asusd/src/daemon.rs
@@ -7,6 +7,7 @@ use asusd::asus_armoury::{start_attributes_zbus, ArmouryAttributeRegistry};
 use asusd::aura_manager::DeviceManager;
 use asusd::config::Config;
 use asusd::ctrl_backlight::CtrlBacklight;
+use asusd::ctrl_dialpad::CtrlDialpad;
 use asusd::ctrl_fancurves::CtrlFanCurveZbus;
 use asusd::ctrl_platform::CtrlPlatform;
 use asusd::ctrl_xgm_led::CtrlXgmLed;
@@ -160,6 +161,16 @@ async fn start_daemon() -> Result<(), Box<dyn Error>> {
         }
         Ok(None) => info!("XG Mobile LED: not present"),
         Err(e) => error!("XG Mobile LED: {e}"),
+    }
+
+    // DialPad controller (non-fatal if not present)
+    match CtrlDialpad::try_new(config.clone()).await {
+        Ok(Some(ctrl)) => {
+            info!("DialPad: found and initialized");
+            ctrl.add_to_server(&mut server).await;
+        }
+        Ok(None) => info!("DialPad: not present"),
+        Err(e) => error!("DialPad: {e}"),
     }
 
     // Request dbus name after finishing initalizing all functions

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -2,6 +2,7 @@
 /// Configuration loading, saving
 pub mod config;
 pub mod ctrl_backlight;
+pub mod ctrl_dialpad;
 /// Control platform profiles + fan-curves if available
 pub mod ctrl_fancurves;
 /// Control ASUS bios function such as boot sound, Optimus/Dedicated gfx mode

--- a/rog-dbus/src/lib.rs
+++ b/rog-dbus/src/lib.rs
@@ -6,6 +6,7 @@ pub mod scsi_aura;
 pub mod zbus_anime;
 pub mod zbus_aura;
 pub mod zbus_backlight;
+pub mod zbus_dialpad;
 pub mod zbus_fan_curves;
 pub mod zbus_platform;
 pub mod zbus_slash;

--- a/rog-dbus/src/zbus_dialpad.rs
+++ b/rog-dbus/src/zbus_dialpad.rs
@@ -1,0 +1,26 @@
+//! # D-Bus interface proxy for: `xyz.ljones.Dialpad`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "xyz.ljones.Dialpad",
+    default_service = "xyz.ljones.Asusd",
+    default_path = "/xyz/ljones/Dialpad"
+)]
+pub trait Dialpad {
+    /// Enable property
+    #[zbus(property)]
+    fn enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// Brightness property
+    #[zbus(property)]
+    fn brightness(&self) -> zbus::Result<u8>;
+    #[zbus(property)]
+    fn set_brightness(&self, value: u8) -> zbus::Result<()>;
+
+    /// Supported property
+    #[zbus(property)]
+    fn supported(&self) -> zbus::Result<bool>;
+}

--- a/rog-platform/src/dialpad.rs
+++ b/rog-platform/src/dialpad.rs
@@ -1,0 +1,89 @@
+use std::fs;
+use std::path::PathBuf;
+
+use log::{info, warn};
+
+use crate::error::{PlatformError, Result};
+use crate::{attr_num, to_device};
+
+/// ASUS WMI Device ID for DialPad hardware toggle (`IIA0 == 0x00100063`)
+pub const ASUS_WMI_DEVID_DIALPAD: u32 = 0x00100063;
+
+/// The Dialpad device provides access to ASUS DialPad backlight and hardware status.
+///
+/// Note: The hardware enabled state is inferred via `brightness > 0` as a heuristic,
+/// supplemented by optional WMI ACPI state toggle calls (`0x00100063`).
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
+pub struct Dialpad {
+    path: PathBuf,
+    wmi_dev_id_path: Option<PathBuf>,
+}
+
+impl Dialpad {
+    attr_num!("brightness", path, u8);
+    attr_num!("max_brightness", path, u8);
+
+    pub fn new() -> Result<Self> {
+        let wmi_path = PathBuf::from("/sys/devices/platform/asus-wmi/dev_id");
+        let wmi_dev_id_path = if wmi_path.exists() {
+            Some(wmi_path)
+        } else {
+            None
+        };
+
+        let mut enumerator = udev::Enumerator::new().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("enumerator failed".into(), err)
+        })?;
+        enumerator.match_subsystem("leds").map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("match_subsystem failed".into(), err)
+        })?;
+
+        for device in enumerator.scan_devices().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("scan_devices failed".into(), err)
+        })? {
+            let name = device.sysname().to_string_lossy();
+            if name == "asus::dialpad" || name == "asus_dialpad" || name.contains("dialpad") {
+                info!("Found DialPad LED device at {:?}", device.syspath());
+                return Ok(Self {
+                    path: device.syspath().to_path_buf(),
+                    wmi_dev_id_path,
+                });
+            }
+        }
+
+        let fallback_path = PathBuf::from("/sys/class/leds/asus::dialpad");
+        if fallback_path.exists() {
+            info!("Found DialPad LED at fallback path {:?}", fallback_path);
+            return Ok(Self {
+                path: fallback_path,
+                wmi_dev_id_path,
+            });
+        }
+
+        Err(PlatformError::MissingFunction(
+            "DialPad LED device not found".into(),
+        ))
+    }
+
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+
+    /// Send WMI command `0x00100063` to toggle hardware DialPad ACPI state.
+    /// Returns an error if the WMI write operation fails.
+    pub fn set_wmi_hardware_state(&self, enabled: bool) -> Result<()> {
+        if let Some(ref wmi_path) = self.wmi_dev_id_path {
+            let val = if enabled { 1 } else { 0 };
+            let cmd = format!("{ASUS_WMI_DEVID_DIALPAD:#x} {val}");
+            info!("Sending WMI command to {wmi_path:?}: {cmd}");
+            fs::write(wmi_path, &cmd).map_err(|e| {
+                warn!("WMI DialPad toggle write failed: {e}");
+                PlatformError::IoPath(wmi_path.to_string_lossy().into(), e)
+            })?;
+        }
+        Ok(())
+    }
+}

--- a/rog-platform/src/lib.rs
+++ b/rog-platform/src/lib.rs
@@ -5,6 +5,7 @@ pub mod asus_armoury;
 pub mod backlight;
 pub mod cled;
 pub mod cpu;
+pub mod dialpad;
 pub mod error;
 pub mod gpu_pci;
 pub mod hid_raw;


### PR DESCRIPTION
# Description
Add hardware controller and CLI support for the ASUS Touchpad DialPad feature found on ASUS ProArt StudioBook, ZenBook, Vivobook, and ROG Flow laptops.
### Summary of Changes:
- **`rog-platform`**: Added `Dialpad` device abstraction using `udev` / sysfs detection for `asus::dialpad` LED device and attributes.
- **`rog-dbus`**: Defined `xyz.ljones.Dialpad` D-Bus interface proxy for path `/xyz/ljones/Dialpad`.
- **`asusd`**: Added `CtrlDialpad` controller (`ZbusRun`, `Reloadable`) to manage state and backlight, with persisted configuration fields `dialpad_enabled` and `dialpad_brightness` in `Config`.
- **`asusctl`**: Added `dialpad` subcommand supporting `get`, `enable <true/false>`, and `brightness <0-255>`.
## Tested Hardware & Environment
- **ASUS Laptop Model:** ASUS ProArt / ZenBook / ROG Flow
- **Linux Distribution:** Arch Linux / Fedora
- **Kernel Version:** 6.x
# Verification and testing:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)