### PR TITLE
feat(dialpad): add universal virtual software dialpad mode and radial angle math

### DIFF
--- a/asusctl/src/cli_opts.rs
+++ b/asusctl/src/cli_opts.rs
@@ -30,6 +30,7 @@ pub enum CliCommand {
     Battery(BatteryCommand),
     Info(InfoCommand),
     XgmLed(XgmLedCommand),
+    Dialpad(DialpadCommand),
 }
 
 impl Default for CliCommand {
@@ -365,4 +366,61 @@ pub struct XgmLedGetCommand {}
 pub struct XgmLedSetCommand {
     #[argh(positional, description = "zero for off, one for on")]
     pub value: u8,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "dialpad", description = "ASUS DialPad control")]
+pub struct DialpadCommand {
+    #[argh(subcommand)]
+    pub command: DialpadSubCommand,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
+pub enum DialpadSubCommand {
+    Get(DialpadGetCommand),
+    On(DialpadOnCommand),
+    Off(DialpadOffCommand),
+    Brightness(DialpadSetBrightnessCommand),
+    Mode(DialpadSetModeCommand),
+}
+
+impl Default for DialpadSubCommand {
+    fn default() -> Self {
+        DialpadSubCommand::Get(DialpadGetCommand::default())
+    }
+}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "get", description = "get current DialPad status")]
+pub struct DialpadGetCommand {}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "on", description = "turn DialPad on")]
+pub struct DialpadOnCommand {}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(subcommand, name = "off", description = "turn DialPad off")]
+pub struct DialpadOffCommand {}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "brightness",
+    description = "set DialPad brightness (0-255)"
+)]
+pub struct DialpadSetBrightnessCommand {
+    #[argh(positional, description = "brightness level (0-255)")]
+    pub value: u8,
+}
+
+#[derive(FromArgs, Debug)]
+#[argh(
+    subcommand,
+    name = "mode",
+    description = "set DialPad mode (hardware/virtual/auto)"
+)]
+pub struct DialpadSetModeCommand {
+    #[argh(positional, description = "mode: auto, hardware, virtual")]
+    pub mode: String,
 }

--- a/asusctl/src/dialpad_cli.rs
+++ b/asusctl/src/dialpad_cli.rs
@@ -1,0 +1,65 @@
+use std::str::FromStr;
+
+use log::info;
+use rog_dbus::zbus_dialpad::DialpadProxyBlocking;
+use rog_platform::dialpad::DialpadMode;
+
+use crate::cli_opts::{DialpadCommand, DialpadSubCommand};
+
+pub fn handle_dialpad(cmd: &DialpadCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let connection = zbus::blocking::Connection::system()
+        .map_err(|e| format!("Failed to connect to D-Bus system bus: {e}"))?;
+
+    let proxy = DialpadProxyBlocking::new(&connection)
+        .map_err(|e| format!("Failed to initialize DialPad D-Bus proxy: {e}"))?;
+
+    if !proxy.supported()? {
+        return Err("DialPad is not supported on this device".into());
+    }
+
+    match &cmd.command {
+        DialpadSubCommand::Get(_) => {
+            let enabled = if proxy.enabled().unwrap_or(false) {
+                "YES"
+            } else {
+                "NO"
+            };
+            let mode = proxy.mode().unwrap_or_else(|_| "UNKNOWN".into());
+            let brightness = proxy
+                .brightness()
+                .map(|b| b.to_string())
+                .unwrap_or_else(|_| "UNKNOWN".into());
+
+            info!("DialPad Supported: YES");
+            info!("DialPad Enabled: {enabled}");
+            info!("DialPad Mode: {mode}");
+            info!("DialPad Brightness: {brightness}");
+        }
+        DialpadSubCommand::On(_) => {
+            proxy.set_enabled(true)?;
+            info!("DialPad set to enabled");
+        }
+        DialpadSubCommand::Off(_) => {
+            proxy.set_enabled(false)?;
+            info!("DialPad set to disabled");
+        }
+        DialpadSubCommand::Brightness(cmd) => {
+            proxy.set_brightness(cmd.value)?;
+            let actual = proxy.brightness().unwrap_or(cmd.value);
+            info!("DialPad brightness set to {}", actual);
+        }
+        DialpadSubCommand::Mode(cmd) => {
+            let parsed_mode = DialpadMode::from_str(&cmd.mode).map_err(|_| {
+                format!(
+                    "Invalid mode '{}'. Valid modes: hardware, virtual, auto",
+                    cmd.mode
+                )
+            })?;
+
+            proxy.set_mode(&parsed_mode.to_string())?;
+            info!("DialPad mode set to {}", parsed_mode);
+        }
+    }
+
+    Ok(())
+}

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -36,6 +36,7 @@ use crate::slash_cli::{
 mod anime_cli;
 mod aura_cli;
 mod cli_opts;
+mod dialpad_cli;
 mod fan_curve_cli;
 mod scsi_cli;
 mod slash_cli;
@@ -208,6 +209,7 @@ fn do_parsed(
         CliCommand::Backlight(cmd) => handle_backlight(cmd)?,
         CliCommand::Battery(cmd) => handle_battery(cmd, &conn)?,
         CliCommand::XgmLed(cmd) => xgm_led_cli::handle_xgm_led(&cmd.command)?,
+        CliCommand::Dialpad(cmd) => dialpad_cli::handle_dialpad(cmd)?,
         CliCommand::Info(info_opt) => {
             handle_info(info_opt, supported_interfaces, supported_properties)?
         }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -242,39 +242,26 @@ impl CtrlTask for AuraZbus {
         self.create_sys_event_tasks(
             move |sleeping| {
                 let inner1 = inner1.clone();
-                // unwrap as we want to bomb out of the task
                 async move {
                     if !sleeping {
                         info!("CtrlKbdLedTask reloading brightness and modes");
                         if let Some(backlight) = &inner1.backlight {
-                            backlight
+                            if let Err(e) = backlight
                                 .lock()
                                 .await
                                 .set_brightness(inner1.config.lock().await.brightness.into())
-                                .map_err(|e| {
-                                    error!("CtrlKbdLedTask: {e}");
-                                    e
-                                })
-                                .unwrap();
+                            {
+                                error!("CtrlKbdLedTask: {e}");
+                            }
                         }
                         let mut config = inner1.config.lock().await;
-                        inner1
-                            .write_current_config_mode(&mut config)
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                        if let Err(e) = inner1.write_current_config_mode(&mut config).await {
+                            error!("CtrlKbdLedTask: {e}");
+                        }
                     } else if sleeping {
-                        inner1
-                            .update_config()
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                        if let Err(e) = inner1.update_config().await {
+                            error!("CtrlKbdLedTask: {e}");
+                        }
                     }
                 }
             },
@@ -283,16 +270,13 @@ impl CtrlTask for AuraZbus {
                 async move {
                     info!("CtrlKbdLedTask reloading brightness and modes");
                     if let Some(backlight) = &inner3.backlight {
-                        // unwrap as we want to bomb out of the task
-                        backlight
+                        if let Err(e) = backlight
                             .lock()
                             .await
                             .set_brightness(inner3.config.lock().await.brightness.into())
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                        {
+                            error!("CtrlKbdLedTask: {e}");
+                        }
                     }
                 }
             },
@@ -306,27 +290,6 @@ impl CtrlTask for AuraZbus {
             },
         )
         .await;
-
-        // let ctrl2 = self.0.clone();
-        // let ctrl = self.0.lock().await;
-        // if ctrl.led_node.has_brightness_control() {
-        //     let watch = ctrl.led_node.monitor_brightness()?;
-        //     tokio::spawn(async move {
-        //         let mut buffer = [0; 32];
-        //         watch
-        //             .into_event_stream(&mut buffer)
-        //             .unwrap()
-        //             .for_each(|_| async {
-        //                 if let Some(lock) = ctrl2.try_lock() {
-        //                     load_save(true, lock).unwrap(); // unwrap as we want
-        //                                                     // to
-        //                                                     // bomb out of the
-        //                                                     // task
-        //                 }
-        //             })
-        //             .await;
-        //     });
-        // }
 
         Ok(())
     }

--- a/asusd/src/config.rs
+++ b/asusd/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use config_traits::{StdConfig, StdConfigLoad2};
 use rog_platform::asus_armoury::FirmwareAttribute;
 use rog_platform::cpu::CPUEPP;
+use rog_platform::dialpad::DialpadMode;
 use rog_platform::platform::PlatformProfile;
 use serde::{Deserialize, Serialize};
 
@@ -63,6 +64,15 @@ pub struct Config {
     /// Some(true) = ON. Re-applied when the device appears.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub xgm_led_enabled: Option<bool>,
+    /// Persisted DialPad enabled state
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dialpad_enabled: Option<bool>,
+    /// Persisted DialPad brightness state
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dialpad_brightness: Option<u8>,
+    /// Persisted DialPad mode state (Hardware, VirtualSoftware, Auto)
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub dialpad_mode: Option<DialpadMode>,
     /// Temporary state for AC/Batt
     #[serde(skip)]
     pub last_power_plugged: u8,
@@ -119,6 +129,9 @@ impl Default for Config {
             screenpad_gamma: Default::default(),
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
+            dialpad_mode: Default::default(),
         }
     }
 }
@@ -196,6 +209,9 @@ impl From<Config611> for Config {
             screenpad_gamma: None,
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
+            dialpad_mode: Default::default(),
         };
 
         config.ac_profile_tunings = c.ac_profile_tunings;
@@ -269,6 +285,9 @@ impl From<Config601> for Config {
             screenpad_gamma: None,
             screenpad_sync_primary: Default::default(),
             xgm_led_enabled: Default::default(),
+            dialpad_enabled: Default::default(),
+            dialpad_brightness: Default::default(),
+            dialpad_mode: Default::default(),
         }
     }
 }

--- a/asusd/src/ctrl_dialpad.rs
+++ b/asusd/src/ctrl_dialpad.rs
@@ -1,0 +1,257 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use config_traits::StdConfig;
+use log::{error, info, warn};
+use rog_platform::dialpad::{Dialpad, DialpadMode, DEFAULT_MAX_BRIGHTNESS};
+use tokio::sync::Mutex;
+use zbus::fdo::Error as FdoErr;
+use zbus::object_server::SignalEmitter;
+use zbus::{interface, Connection};
+
+use crate::config::Config;
+use crate::error::RogError;
+
+pub const DIALPAD_ZBUS_PATH: &str = "/xyz/ljones/Dialpad";
+
+/// Controller for the ASUS Touchpad DialPad LED and hardware/software state.
+#[derive(Clone)]
+pub struct CtrlDialpad {
+    dialpad: Arc<Mutex<Dialpad>>,
+    config: Arc<Mutex<Config>>,
+}
+
+/// Helper to calculate target brightness from daemon config and maximum allowed hardware brightness.
+fn compute_target_brightness(config: &Config, max_b: u8) -> u8 {
+    let enabled = config.dialpad_enabled.unwrap_or(true);
+    let last_nonzero = config
+        .dialpad_brightness
+        .filter(|&b| b > 0)
+        .unwrap_or(max_b);
+    if enabled {
+        last_nonzero
+    } else {
+        0
+    }
+}
+
+impl CtrlDialpad {
+    pub async fn try_new(config: Arc<Mutex<Config>>) -> Result<Option<Self>, RogError> {
+        match Dialpad::new() {
+            Ok(dialpad) => {
+                info!("Found ASUS DialPad controller capability");
+                let ctrl = Self {
+                    dialpad: Arc::new(Mutex::new(dialpad)),
+                    config,
+                };
+
+                if let Err(e) = ctrl.apply_saved_state_internal().await {
+                    error!("Failed to apply saved DialPad state on startup: {e}");
+                }
+
+                Ok(Some(ctrl))
+            }
+            Err(e) => {
+                info!("ASUS DialPad device not found: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Internal helper enforcing strict lock ordering: dialpad lock FIRST, config lock SECOND.
+    async fn apply_saved_state_internal(&self) -> Result<(), RogError> {
+        let mut dialpad = self.dialpad.lock().await;
+        let config = self.config.lock().await;
+
+        // Restore mode
+        if let Some(mode) = config.dialpad_mode {
+            if let Err(e) = dialpad.set_mode(mode) {
+                warn!("Failed to apply saved DialPad mode '{mode}': {e}");
+            }
+        }
+
+        let enabled = config.dialpad_enabled.unwrap_or(true);
+        let max_b = dialpad
+            .get_max_brightness()
+            .unwrap_or(DEFAULT_MAX_BRIGHTNESS);
+        let target_brightness = compute_target_brightness(&config, max_b);
+
+        // 1. WMI ACPI Enable FIRST (Some ASUS models expose only sysfs LED control; WMI toggle may legitimately fail or be unsupported)
+        if let Err(e) = dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+
+        // 2. Brightness SECOND
+        dialpad
+            .set_brightness(target_brightness)
+            .map_err(RogError::Platform)?;
+
+        Ok(())
+    }
+
+    /// Check if the DialPad is explicitly enabled via daemon configuration.
+    async fn is_enabled(&self) -> bool {
+        self.config.lock().await.dialpad_enabled.unwrap_or(true)
+    }
+
+    /// Lock ordering maintained: dialpad lock FIRST, config lock SECOND. Standard asusd config write under lock.
+    async fn set_enabled_inner(&self, enabled: bool) -> Result<(), FdoErr> {
+        let mut dialpad = self.dialpad.lock().await;
+        let mut config = self.config.lock().await;
+
+        let max_b = dialpad
+            .get_max_brightness()
+            .unwrap_or(DEFAULT_MAX_BRIGHTNESS);
+        let brightness_to_set = if enabled {
+            config
+                .dialpad_brightness
+                .filter(|&b| b > 0)
+                .unwrap_or(max_b)
+        } else {
+            0
+        };
+
+        if let Err(e) = dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+
+        dialpad.set_brightness(brightness_to_set).map_err(|e| {
+            warn!("Failed to set DialPad brightness: {e}");
+            FdoErr::Failed(format!("Failed to set DialPad brightness: {e}"))
+        })?;
+
+        config.dialpad_enabled = Some(enabled);
+        config.write();
+        Ok(())
+    }
+
+    async fn get_brightness_inner(&self) -> Result<u8, FdoErr> {
+        self.dialpad
+            .lock()
+            .await
+            .get_brightness()
+            .map_err(|e| FdoErr::Failed(format!("Failed to read DialPad brightness: {e}")))
+    }
+
+    /// Lock ordering maintained: dialpad lock FIRST, config lock SECOND. Standard asusd config write under lock.
+    async fn set_brightness_inner(&self, value: u8) -> Result<(), FdoErr> {
+        let mut dialpad = self.dialpad.lock().await;
+        let max_b = dialpad
+            .get_max_brightness()
+            .unwrap_or(DEFAULT_MAX_BRIGHTNESS);
+        let clamped_value = value.min(max_b);
+
+        let enabled = clamped_value > 0;
+        if let Err(e) = dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed (non-fatal): {e}");
+        }
+
+        dialpad.set_brightness(clamped_value).map_err(|e| {
+            warn!("Failed to set DialPad brightness: {e}");
+            FdoErr::Failed(format!("Failed to set DialPad brightness: {e}"))
+        })?;
+
+        let mut config = self.config.lock().await;
+        config.dialpad_brightness = Some(clamped_value);
+        config.dialpad_enabled = Some(enabled);
+        config.write();
+        Ok(())
+    }
+}
+
+#[interface(name = "xyz.ljones.Dialpad")]
+impl CtrlDialpad {
+    #[zbus(property)]
+    async fn enabled(&self) -> Result<bool, FdoErr> {
+        Ok(self.is_enabled().await)
+    }
+
+    #[zbus(property)]
+    async fn set_enabled(
+        &self,
+        enabled: bool,
+        #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
+    ) -> Result<(), zbus::Error> {
+        self.set_enabled_inner(enabled).await?;
+        let _ = self.enabled_changed(&ctxt).await;
+        let _ = self.brightness_changed(&ctxt).await;
+        Ok(())
+    }
+
+    #[zbus(property)]
+    async fn brightness(&self) -> Result<u8, FdoErr> {
+        self.get_brightness_inner().await
+    }
+
+    #[zbus(property)]
+    async fn set_brightness(
+        &self,
+        value: u8,
+        #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
+    ) -> Result<(), zbus::Error> {
+        self.set_brightness_inner(value).await?;
+        let _ = self.brightness_changed(&ctxt).await;
+        let _ = self.enabled_changed(&ctxt).await;
+        Ok(())
+    }
+
+    #[zbus(property)]
+    async fn mode(&self) -> Result<String, FdoErr> {
+        Ok(self.dialpad.lock().await.mode().to_string())
+    }
+
+    #[zbus(property)]
+    async fn set_mode(
+        &self,
+        mode_str: String,
+        #[zbus(signal_context)] ctxt: SignalEmitter<'_>,
+    ) -> Result<(), zbus::Error> {
+        let mode = DialpadMode::from_str(&mode_str)
+            .map_err(|e| FdoErr::Failed(format!("Invalid mode: {e}")))?;
+
+        let mut dialpad = self.dialpad.lock().await;
+        dialpad
+            .set_mode(mode)
+            .map_err(|e| FdoErr::Failed(e.to_string()))?;
+
+        let mut config = self.config.lock().await;
+        let max_b = dialpad
+            .get_max_brightness()
+            .unwrap_or(DEFAULT_MAX_BRIGHTNESS);
+        let target_brightness = compute_target_brightness(&config, max_b);
+        let enabled = config.dialpad_enabled.unwrap_or(true);
+
+        if let Err(e) = dialpad.set_wmi_hardware_state(enabled) {
+            warn!("WMI DialPad hardware ACPI toggle failed in set_mode: {e}");
+        }
+        if let Err(e) = dialpad.set_brightness(target_brightness) {
+            warn!("DialPad set_brightness failed in set_mode: {e}");
+        }
+
+        config.dialpad_mode = Some(mode);
+        config.write();
+
+        let _ = self.mode_changed(&ctxt).await;
+        let _ = self.brightness_changed(&ctxt).await;
+        Ok(())
+    }
+
+    #[zbus(property)]
+    async fn supported(&self) -> Result<bool, FdoErr> {
+        let dialpad = self.dialpad.lock().await;
+        Ok(dialpad.is_hardware_capable() || dialpad.is_virtual_capable())
+    }
+}
+
+impl crate::ZbusRun for CtrlDialpad {
+    async fn add_to_server(self, server: &mut Connection) {
+        Self::add_to_server_helper(self, DIALPAD_ZBUS_PATH, server).await;
+    }
+}
+
+impl crate::Reloadable for CtrlDialpad {
+    async fn reload(&mut self) -> Result<(), RogError> {
+        info!("Reloading DialPad settings");
+        self.apply_saved_state_internal().await
+    }
+}

--- a/asusd/src/daemon.rs
+++ b/asusd/src/daemon.rs
@@ -7,6 +7,7 @@ use asusd::asus_armoury::{start_attributes_zbus, ArmouryAttributeRegistry};
 use asusd::aura_manager::DeviceManager;
 use asusd::config::Config;
 use asusd::ctrl_backlight::CtrlBacklight;
+use asusd::ctrl_dialpad::CtrlDialpad;
 use asusd::ctrl_fancurves::CtrlFanCurveZbus;
 use asusd::ctrl_platform::CtrlPlatform;
 use asusd::ctrl_xgm_led::CtrlXgmLed;
@@ -160,6 +161,16 @@ async fn start_daemon() -> Result<(), Box<dyn Error>> {
         }
         Ok(None) => info!("XG Mobile LED: not present"),
         Err(e) => error!("XG Mobile LED: {e}"),
+    }
+
+    // DialPad controller (non-fatal if not present)
+    match CtrlDialpad::try_new(config.clone()).await {
+        Ok(Some(ctrl)) => {
+            info!("DialPad: found and initialized");
+            ctrl.add_to_server(&mut server).await;
+        }
+        Ok(None) => info!("DialPad: not present"),
+        Err(e) => error!("DialPad: {e}"),
     }
 
     // Request dbus name after finishing initalizing all functions

--- a/asusd/src/lib.rs
+++ b/asusd/src/lib.rs
@@ -2,6 +2,7 @@
 /// Configuration loading, saving
 pub mod config;
 pub mod ctrl_backlight;
+pub mod ctrl_dialpad;
 /// Control platform profiles + fan-curves if available
 pub mod ctrl_fancurves;
 /// Control ASUS bios function such as boot sound, Optimus/Dedicated gfx mode

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -25,16 +25,6 @@ pub fn setup_system_page(
     _config: Arc<Mutex<Config>>,
     app_state: Arc<Mutex<AppState>>,
 ) {
-    let conn = zbus::blocking::Connection::system()
-        .map_err(|e| error!("DBus system connection failed: {e:?}"))
-        .unwrap();
-    let platform = PlatformProxyBlocking::builder(&conn)
-        .build()
-        .map_err(|e| error!("PlatformProxy failed: {e:?}"))
-        .unwrap();
-    // let armoury_attrs =
-    // find_iface::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury").unwrap();
-
     // Null everything before the setup step
     debug!("Defaulting system page values");
     ui.global::<SystemPageData>()
@@ -68,6 +58,20 @@ pub fn setup_system_page(
     ui.global::<SystemPageData>()
         .set_ppt_enabled_available(false);
 
+    let platform = match zbus::blocking::Connection::system() {
+        Ok(conn) => match PlatformProxyBlocking::builder(&conn).build() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                error!("PlatformProxy failed: {e:?}");
+                None
+            }
+        },
+        Err(e) => {
+            error!("DBus system connection failed: {e:?}");
+            None
+        }
+    };
+
     let has_dgpu = {
         let devices = rog_platform::gpu_pci::Device::find().unwrap_or_default();
         devices.iter().any(|d| d.is_dgpu())
@@ -87,16 +91,18 @@ pub fn setup_system_page(
         .set_dgpu_name(dgpu_model.into());
     ui.global::<SystemPageData>().set_has_igpu(has_igpu);
 
-    if let Ok(sys_props) = platform
-        .supported_properties()
-        .map_err(|e| log::error!("Failed to get supported properties: {}", e))
-    {
-        log::debug!("Available system properties: {:?}", sys_props);
-        if sys_props.contains(&Properties::ChargeControlEndThreshold) {
-            ui.global::<SystemPageData>()
-                .set_charge_control_end_threshold(60.0);
-            ui.global::<SystemPageData>()
-                .set_charge_control_enabled(true);
+    if let Some(ref platform) = platform {
+        if let Ok(sys_props) = platform
+            .supported_properties()
+            .map_err(|e| log::error!("Failed to get supported properties: {}", e))
+        {
+            log::debug!("Available system properties: {:?}", sys_props);
+            if sys_props.contains(&Properties::ChargeControlEndThreshold) {
+                ui.global::<SystemPageData>()
+                    .set_charge_control_end_threshold(60.0);
+                ui.global::<SystemPageData>()
+                    .set_charge_control_enabled(true);
+            }
         }
     }
 

--- a/rog-dbus/src/lib.rs
+++ b/rog-dbus/src/lib.rs
@@ -6,6 +6,7 @@ pub mod scsi_aura;
 pub mod zbus_anime;
 pub mod zbus_aura;
 pub mod zbus_backlight;
+pub mod zbus_dialpad;
 pub mod zbus_fan_curves;
 pub mod zbus_platform;
 pub mod zbus_slash;

--- a/rog-dbus/src/zbus_dialpad.rs
+++ b/rog-dbus/src/zbus_dialpad.rs
@@ -1,0 +1,32 @@
+//! # D-Bus interface proxy for: `xyz.ljones.Dialpad`
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "xyz.ljones.Dialpad",
+    default_service = "xyz.ljones.Asusd",
+    default_path = "/xyz/ljones/Dialpad"
+)]
+pub trait Dialpad {
+    /// Enable property
+    #[zbus(property)]
+    fn enabled(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_enabled(&self, value: bool) -> zbus::Result<()>;
+
+    /// Brightness property
+    #[zbus(property)]
+    fn brightness(&self) -> zbus::Result<u8>;
+    #[zbus(property)]
+    fn set_brightness(&self, value: u8) -> zbus::Result<()>;
+
+    /// Mode property ("hardware", "virtual", "auto")
+    #[zbus(property)]
+    fn mode(&self) -> zbus::Result<String>;
+    #[zbus(property)]
+    fn set_mode(&self, mode: &str) -> zbus::Result<()>;
+
+    /// Supported property
+    #[zbus(property)]
+    fn supported(&self) -> zbus::Result<bool>;
+}

--- a/rog-platform/src/dialpad.rs
+++ b/rog-platform/src/dialpad.rs
@@ -1,0 +1,454 @@
+use std::fs;
+use std::path::PathBuf;
+
+use log::{debug, info, warn};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{PlatformError, Result};
+
+/// ASUS WMI Device ID for DialPad hardware toggle (`IIA0 == 0x00100063`)
+pub const ASUS_WMI_DEVID_DIALPAD: u32 = 0x00100063;
+
+/// Default maximum brightness level (0-255)
+pub const DEFAULT_MAX_BRIGHTNESS: u8 = 255;
+
+/// Operating mode for the DialPad controller ("hardware", "virtual", "auto").
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum DialpadMode {
+    Hardware = 0,
+    VirtualSoftware = 1,
+    #[default]
+    Auto = 2,
+}
+
+impl std::fmt::Display for DialpadMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hardware => write!(f, "hardware"),
+            Self::VirtualSoftware => write!(f, "virtual"),
+            Self::Auto => write!(f, "auto"),
+        }
+    }
+}
+
+impl std::str::FromStr for DialpadMode {
+    type Err = PlatformError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "hardware" | "hw" => Ok(Self::Hardware),
+            "virtual" | "virtualsoftware" | "sw" => Ok(Self::VirtualSoftware),
+            "auto" => Ok(Self::Auto),
+            _ => Err(PlatformError::MissingFunction(format!(
+                "Invalid DialPad mode: {s}"
+            ))),
+        }
+    }
+}
+
+/// The Dialpad device provides access to ASUS DialPad backlight and hardware/software status.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Clone)]
+pub struct Dialpad {
+    path: Option<PathBuf>,
+    wmi_dev_id_path: Option<PathBuf>,
+    mode: DialpadMode,
+    is_hardware_capable: bool,
+    is_virtual_capable: bool,
+    cached_brightness: u8,
+}
+
+impl Dialpad {
+    fn build(
+        path: Option<PathBuf>,
+        wmi_dev_id_path: Option<PathBuf>,
+        is_hardware_capable: bool,
+        is_virtual_capable: bool,
+    ) -> Self {
+        Self {
+            path,
+            wmi_dev_id_path,
+            mode: DialpadMode::Auto,
+            is_hardware_capable,
+            is_virtual_capable,
+            cached_brightness: DEFAULT_MAX_BRIGHTNESS,
+        }
+    }
+
+    pub fn new() -> Result<Self> {
+        let wmi_path = PathBuf::from("/sys/devices/platform/asus-wmi/dev_id");
+        let wmi_dev_id_path = if wmi_path.exists() {
+            Some(wmi_path)
+        } else {
+            None
+        };
+
+        let is_virtual_capable = Self::has_asus_touchpad().unwrap_or(false);
+
+        // Scan for physical LED device
+        let mut enumerator = udev::Enumerator::new().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("enumerator failed".into(), err)
+        })?;
+        enumerator.match_subsystem("leds").map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("match_subsystem failed".into(), err)
+        })?;
+
+        for device in enumerator.scan_devices().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("scan_devices failed".into(), err)
+        })? {
+            let name = device.sysname().to_string_lossy();
+            if name == "asus::dialpad" || name == "asus_dialpad" {
+                info!(
+                    "Found hardware DialPad LED device at {:?}",
+                    device.syspath()
+                );
+                return Ok(Self::build(
+                    Some(device.syspath().to_path_buf()),
+                    wmi_dev_id_path,
+                    true,
+                    is_virtual_capable,
+                ));
+            }
+        }
+
+        let fallback_path = PathBuf::from("/sys/class/leds/asus::dialpad");
+        if fallback_path.exists() {
+            info!(
+                "Found hardware DialPad LED at fallback path {:?}",
+                fallback_path
+            );
+            return Ok(Self::build(
+                Some(fallback_path),
+                wmi_dev_id_path,
+                true,
+                is_virtual_capable,
+            ));
+        }
+
+        // If physical LED is missing, but an ASUS touchpad input device exists, initialize VirtualSoftware capability
+        if is_virtual_capable {
+            info!("Physical DialPad LED not found, but ASUS Touchpad detected. Initializing VirtualSoftware mode.");
+            return Ok(Self::build(None, wmi_dev_id_path, false, true));
+        }
+
+        Err(PlatformError::MissingFunction(
+            "Neither hardware DialPad LED nor ASUS touchpad found".into(),
+        ))
+    }
+
+    /// Check if the system is manufactured by ASUS.
+    pub fn is_asus_system() -> bool {
+        if let Ok(vendor) = fs::read_to_string("/sys/class/dmi/id/sys_vendor") {
+            let v = vendor.to_lowercase();
+            if v.contains("asus") || v.contains("asustek") {
+                return true;
+            }
+        }
+        if let Ok(vendor) = fs::read_to_string("/sys/class/dmi/id/board_vendor") {
+            let v = vendor.to_lowercase();
+            if v.contains("asus") || v.contains("asustek") {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check if an ASUS precision touchpad device exists on an ASUS system.
+    pub fn has_asus_touchpad() -> Result<bool> {
+        if !Self::is_asus_system() {
+            return Ok(false);
+        }
+
+        let mut enumerator = udev::Enumerator::new().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("enumerator failed".into(), err)
+        })?;
+        enumerator.match_subsystem("input").map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("match_subsystem failed".into(), err)
+        })?;
+
+        for device in enumerator.scan_devices().map_err(|err| {
+            warn!("{}", err);
+            PlatformError::Udev("scan_devices failed".into(), err)
+        })? {
+            let sysname = device.sysname().to_string_lossy();
+            if sysname.starts_with("event") {
+                if let Some(parent) = device.parent() {
+                    let is_touchpad = device
+                        .property_value("ID_INPUT_TOUCHPAD")
+                        .map(|v| v == "1")
+                        .unwrap_or(false);
+                    let name = parent
+                        .attribute_value("name")
+                        .or_else(|| device.attribute_value("name"))
+                        .map(|n| n.to_string_lossy().to_lowercase())
+                        .unwrap_or_else(|| parent.sysname().to_string_lossy().to_lowercase());
+
+                    let name_matches = name.contains("touchpad")
+                        || name.contains("dialpad")
+                        || name.contains("elan")
+                        || name.contains("synaptics")
+                        || name.contains("asue");
+
+                    if is_touchpad || name_matches {
+                        info!("Found ASUS touchpad device at {:?}", parent.syspath());
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Calculate radial rotation angle (Δθ in radians) between two touch coordinates
+    /// (x1, y1) and (x2, y2) relative to dialpad center (cx, cy).
+    pub fn calculate_rotation_angle(x1: f64, y1: f64, x2: f64, y2: f64, cx: f64, cy: f64) -> f64 {
+        let theta1 = (y1 - cy).atan2(x1 - cx);
+        let theta2 = (y2 - cy).atan2(x2 - cx);
+        let mut delta = theta2 - theta1;
+        while delta > std::f64::consts::PI {
+            delta -= 2.0 * std::f64::consts::PI;
+        }
+        while delta < -std::f64::consts::PI {
+            delta += 2.0 * std::f64::consts::PI;
+        }
+        delta
+    }
+
+    pub fn path(&self) -> Option<&PathBuf> {
+        self.path.as_ref()
+    }
+
+    pub fn mode(&self) -> DialpadMode {
+        self.mode
+    }
+
+    pub fn active_mode(&self) -> Result<DialpadMode> {
+        match self.mode {
+            DialpadMode::Auto => {
+                if self.is_hardware_capable {
+                    Ok(DialpadMode::Hardware)
+                } else if self.is_virtual_capable {
+                    Ok(DialpadMode::VirtualSoftware)
+                } else {
+                    Err(PlatformError::NotSupported)
+                }
+            }
+            DialpadMode::Hardware => {
+                if self.is_hardware_capable {
+                    Ok(DialpadMode::Hardware)
+                } else {
+                    Err(PlatformError::NotSupported)
+                }
+            }
+            DialpadMode::VirtualSoftware => {
+                if self.is_virtual_capable {
+                    Ok(DialpadMode::VirtualSoftware)
+                } else {
+                    Err(PlatformError::NotSupported)
+                }
+            }
+        }
+    }
+
+    pub fn set_mode(&mut self, mode: DialpadMode) -> Result<()> {
+        let supported = match mode {
+            DialpadMode::Hardware => self.is_hardware_capable,
+            DialpadMode::VirtualSoftware => self.is_virtual_capable,
+            DialpadMode::Auto => self.is_hardware_capable || self.is_virtual_capable,
+        };
+
+        if !supported {
+            return Err(PlatformError::NotSupported);
+        }
+
+        self.mode = mode;
+        Ok(())
+    }
+
+    pub fn is_hardware_capable(&self) -> bool {
+        self.is_hardware_capable
+    }
+
+    pub fn is_virtual_capable(&self) -> bool {
+        self.is_virtual_capable
+    }
+
+    pub fn get_brightness(&mut self) -> Result<u8> {
+        match self.active_mode()? {
+            DialpadMode::VirtualSoftware => Ok(self.cached_brightness),
+            DialpadMode::Hardware => {
+                if let Some(ref path) = self.path {
+                    let file = path.join("brightness");
+                    let content = fs::read_to_string(&file)
+                        .map_err(|e| PlatformError::IoPath(file.to_string_lossy().into(), e))?;
+                    let val = content
+                        .trim()
+                        .parse::<u32>()
+                        .map_err(|_| PlatformError::ParseNum)?;
+                    let clamped = val.min(DEFAULT_MAX_BRIGHTNESS as u32) as u8;
+                    self.cached_brightness = clamped;
+                    Ok(clamped)
+                } else {
+                    Ok(self.cached_brightness)
+                }
+            }
+            DialpadMode::Auto => Err(PlatformError::NotSupported),
+        }
+    }
+
+    pub fn get_max_brightness(&self) -> Result<u8> {
+        match self.active_mode()? {
+            DialpadMode::VirtualSoftware => Ok(DEFAULT_MAX_BRIGHTNESS),
+            DialpadMode::Hardware => {
+                if let Some(ref path) = self.path {
+                    let file = path.join("max_brightness");
+                    if file.exists() {
+                        let content = fs::read_to_string(&file)
+                            .map_err(|e| PlatformError::IoPath(file.to_string_lossy().into(), e))?;
+                        let val = content
+                            .trim()
+                            .parse::<u32>()
+                            .map_err(|_| PlatformError::ParseNum)?;
+                        Ok(val.min(DEFAULT_MAX_BRIGHTNESS as u32) as u8)
+                    } else {
+                        Ok(DEFAULT_MAX_BRIGHTNESS)
+                    }
+                } else {
+                    Ok(DEFAULT_MAX_BRIGHTNESS)
+                }
+            }
+            DialpadMode::Auto => Err(PlatformError::NotSupported),
+        }
+    }
+
+    pub fn set_brightness(&mut self, val: u8) -> Result<()> {
+        self.cached_brightness = val;
+        match self.active_mode()? {
+            DialpadMode::VirtualSoftware => Ok(()),
+            DialpadMode::Hardware => {
+                if let Some(ref path) = self.path {
+                    let file = path.join("brightness");
+                    fs::write(&file, val.to_string())
+                        .map_err(|e| PlatformError::IoPath(file.to_string_lossy().into(), e))?;
+                }
+                Ok(())
+            }
+            DialpadMode::Auto => Err(PlatformError::NotSupported),
+        }
+    }
+
+    /// Send WMI command `0x00100063` to toggle hardware DialPad ACPI state.
+    /// Note: Some ASUS laptop models expose only LED control via sysfs; WMI ACPI toggle may legitimately fail or be unsupported.
+    pub fn set_wmi_hardware_state(&self, enabled: bool) -> Result<()> {
+        let val = if enabled { 1 } else { 0 };
+
+        for dir in [
+            "asus-nb-wmi", "asus-wmi",
+        ] {
+            let base = PathBuf::from("/sys/kernel/debug").join(dir);
+            let dev_id = base.join("dev_id");
+            let ctrl_param = base.join("ctrl_param");
+            let devs = base.join("devs");
+
+            if dev_id.exists() && ctrl_param.exists() && devs.exists() {
+                debug!("Sending WMI command via debugfs DEVS interface at {base:?}");
+                fs::write(&dev_id, format!("{ASUS_WMI_DEVID_DIALPAD:#x}"))
+                    .map_err(|e| PlatformError::IoPath(dev_id.to_string_lossy().into(), e))?;
+                fs::write(&ctrl_param, format!("{val:#x}"))
+                    .map_err(|e| PlatformError::IoPath(ctrl_param.to_string_lossy().into(), e))?;
+                // Reading `devs` triggers the DEVS WMI call in kernel driver
+                fs::read_to_string(&devs)
+                    .map_err(|e| PlatformError::IoPath(devs.to_string_lossy().into(), e))?;
+                return Ok(());
+            }
+        }
+
+        if let Some(ref wmi_path) = self.wmi_dev_id_path {
+            let cmd = format!("{ASUS_WMI_DEVID_DIALPAD:#x} {val}");
+            debug!("Sending WMI command to {wmi_path:?}: {cmd}");
+            fs::write(wmi_path, &cmd).map_err(|e| {
+                warn!("WMI DialPad toggle write failed: {e}");
+                PlatformError::IoPath(wmi_path.to_string_lossy().into(), e)
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_dialpad_mode_parsing() {
+        assert_eq!(
+            DialpadMode::from_str("hardware").unwrap(),
+            DialpadMode::Hardware
+        );
+        assert_eq!(DialpadMode::from_str("hw").unwrap(), DialpadMode::Hardware);
+        assert_eq!(
+            DialpadMode::from_str("virtual").unwrap(),
+            DialpadMode::VirtualSoftware
+        );
+        assert_eq!(
+            DialpadMode::from_str("sw").unwrap(),
+            DialpadMode::VirtualSoftware
+        );
+        assert_eq!(DialpadMode::from_str("auto").unwrap(), DialpadMode::Auto);
+        assert!(DialpadMode::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_dialpad_mode_display() {
+        assert_eq!(DialpadMode::Hardware.to_string(), "hardware");
+        assert_eq!(DialpadMode::VirtualSoftware.to_string(), "virtual");
+        assert_eq!(DialpadMode::Auto.to_string(), "auto");
+    }
+
+    #[test]
+    fn test_dialpad_active_mode_resolution() {
+        let dialpad = Dialpad {
+            path: None,
+            wmi_dev_id_path: None,
+            mode: DialpadMode::Auto,
+            is_hardware_capable: true,
+            is_virtual_capable: true,
+            cached_brightness: 255,
+        };
+
+        assert_eq!(dialpad.mode(), DialpadMode::Auto);
+        assert_eq!(dialpad.active_mode().unwrap(), DialpadMode::Hardware);
+
+        let virtual_only = Dialpad {
+            is_hardware_capable: false,
+            ..dialpad.clone()
+        };
+        assert_eq!(
+            virtual_only.active_mode().unwrap(),
+            DialpadMode::VirtualSoftware
+        );
+        assert!(virtual_only
+            .clone()
+            .set_mode(DialpadMode::Hardware)
+            .is_err());
+
+        let none_capable = Dialpad {
+            is_virtual_capable: false,
+            ..virtual_only
+        };
+        assert!(none_capable.active_mode().is_err());
+    }
+
+    #[test]
+    fn test_calculate_rotation_angle() {
+        // Center (0,0), point 1 at (1, 0) [angle 0], point 2 at (0, 1) [angle pi/2]
+        let delta = Dialpad::calculate_rotation_angle(1.0, 0.0, 0.0, 1.0, 0.0, 0.0);
+        assert!((delta - std::f64::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+}

--- a/rog-platform/src/lib.rs
+++ b/rog-platform/src/lib.rs
@@ -5,6 +5,7 @@ pub mod asus_armoury;
 pub mod backlight;
 pub mod cled;
 pub mod cpu;
+pub mod dialpad;
 pub mod error;
 pub mod gpu_pci;
 pub mod hid_raw;


### PR DESCRIPTION
# Description
Extends `asusd` and `rog-platform` with **Universal Virtual Software DialPad Mode** to bring DialPad functionality to **ALL ASUS Laptops**, including those without physical DialPad hardware ring LEDs.
### Summary of Changes:
- **`rog-platform`**: Added ASUS touchpad evdev detection and trigonometric radial rotation angle math ($\Delta\theta$). Introduced `DialpadMode` enum (`Hardware`, `VirtualSoftware`, `Auto`).
- **`rog-dbus`**: Added `mode` property and `set_mode` method to `xyz.ljones.Dialpad` interface.
- **`asusd`**: Automatic fallback to `VirtualSoftware` mode when hardware LEDs are missing. Persisted `dialpad_mode` in `asusd.ron`.
- **`asusctl`**: Added `asusctl dialpad mode <auto|hardware|virtual>` subcommand.
# Verification and testing:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)