### PR TITLE
[UI redesign 2/3] rog-platform: fan sensor sentinel (missing vs stopped)

### DIFF
--- a/rog-platform/src/platform.rs
+++ b/rog-platform/src/platform.rs
@@ -325,22 +325,25 @@ pub enum Properties {
 }
 
 pub fn get_fan_rpms() -> (i32, i32, i32) {
-    let mut cpu = 0;
-    let mut gpu = 0;
-    let mut mid = 0;
+    // -1 = sensor absent / unreadable; 0 = the fan is genuinely stopped.
+    // Distinguishing them lets the UI show "0 RPM" for an idle fan instead of
+    // treating a legit zero as "no reading".
+    let mut cpu = -1;
+    let mut gpu = -1;
+    let mut mid = -1;
     if let Ok(entries) = std::fs::read_dir("/sys/class/hwmon") {
         for entry in entries.flatten() {
             let path = entry.path();
             if let Ok(name) = std::fs::read_to_string(path.join("name")) {
                 if name.trim() == "asus" {
                     if let Ok(v) = std::fs::read_to_string(path.join("fan1_input")) {
-                        cpu = v.trim().parse().unwrap_or(0);
+                        cpu = v.trim().parse::<i32>().ok().filter(|rpm| *rpm >= 0).unwrap_or(-1);
                     }
                     if let Ok(v) = std::fs::read_to_string(path.join("fan2_input")) {
-                        gpu = v.trim().parse().unwrap_or(0);
+                        gpu = v.trim().parse::<i32>().ok().filter(|rpm| *rpm >= 0).unwrap_or(-1);
                     }
                     if let Ok(v) = std::fs::read_to_string(path.join("fan3_input")) {
-                        mid = v.trim().parse().unwrap_or(0);
+                        mid = v.trim().parse::<i32>().ok().filter(|rpm| *rpm >= 0).unwrap_or(-1);
                     }
                     break;
                 }


### PR DESCRIPTION
Part of the UI redesign stack (2/3) — split out for easier review:

1. #252 — build .mo from .po at build time
2. **this** — fan sensor sentinel
3. #230 — AC-style frontend redesign

The three PRs touch disjoint files and can be reviewed / merged independently in any order.

---

Return `-1` when a fan sensor is absent and `0` when the fan is genuinely stopped, so consumers can tell "no sensor" apart from "idle 0 RPM" instead of treating both as zero. The UI redesign (#230) uses this sentinel to hide the GPU/mid fan rows on devices without those sensors.