### PR TITLE
Add tuning enable/disable and PPT related visibility improvements

### DIFF
--- a/asusctl/src/cli_opts.rs
+++ b/asusctl/src/cli_opts.rs
@@ -52,6 +52,7 @@ pub enum ProfileSubCommand {
     List(ProfileListCommand),
     Get(ProfileGetCommand),
     Set(ProfileSetCommand),
+    Tuning(ProfileTuningCommand),
 }
 
 impl Default for ProfileSubCommand {
@@ -95,6 +96,20 @@ pub struct ProfileSetCommand {
         description = "set the profile to use on battery power"
     )]
     pub battery: bool,
+}
+
+#[derive(FromArgs, Debug, Default)]
+#[argh(
+    subcommand,
+    name = "tuning",
+    description = "enable/disable profile tuning"
+)]
+pub struct ProfileTuningCommand {
+    #[argh(
+        positional,
+        description = "true/false to enable/disable profile tuning respectively. omit to show current state"
+    )]
+    pub enable: Option<bool>,
 }
 
 #[derive(FromArgs, Debug, Default)]

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -20,6 +20,7 @@ use rog_dbus::zbus_aura::AuraProxyBlocking;
 use rog_dbus::zbus_backlight::BacklightProxyBlocking;
 use rog_dbus::zbus_fan_curves::FanCurvesProxyBlocking;
 use rog_dbus::zbus_platform::PlatformProxyBlocking;
+use rog_platform::asus_armoury::FirmwareAttributeType;
 use rog_platform::platform::{PlatformProfile, Properties};
 use rog_profiles::error::ProfileError;
 use rog_scsi::AuraMode;
@@ -204,7 +205,7 @@ fn do_parsed(
         CliCommand::Anime(cmd) => handle_anime(cmd)?,
         CliCommand::Slash(cmd) => handle_slash(cmd)?,
         CliCommand::Scsi(cmd) => handle_scsi(cmd)?,
-        CliCommand::Armoury(cmd) => handle_armoury_command(cmd)?,
+        CliCommand::Armoury(cmd) => handle_armoury_command(cmd, &conn)?,
         CliCommand::Backlight(cmd) => handle_backlight(cmd)?,
         CliCommand::Battery(cmd) => handle_battery(cmd, &conn)?,
         CliCommand::XgmLed(cmd) => xgm_led_cli::handle_xgm_led(&cmd.command)?,
@@ -1023,7 +1024,10 @@ fn print_firmware_attr(attr: &AsusArmouryProxyBlocking) -> Result<(), Box<dyn st
 }
 
 #[allow(clippy::manual_is_multiple_of, clippy::nonminimal_bool)]
-fn handle_armoury_command(cmd: &ArmouryCommand) -> Result<(), Box<dyn std::error::Error>> {
+fn handle_armoury_command(
+    cmd: &ArmouryCommand,
+    conn: &Connection,
+) -> Result<(), Box<dyn std::error::Error>> {
     // If nested subcommand provided, handle set/get/list.
     match &cmd.command {
         ArmourySubCommand::List(_) => {
@@ -1063,6 +1067,24 @@ fn handle_armoury_command(cmd: &ArmouryCommand) -> Result<(), Box<dyn std::error
                         value = attr.default_value()?;
                     }
                     attr.set_current_value(value)?;
+
+                    if attr.name()?.property_type() == FirmwareAttributeType::Ppt {
+                        // Only Ok(true) means the value was applied to hardware now
+                        match PlatformProxyBlocking::new(conn).and_then(|p| p.enable_ppt_group()) {
+                            Ok(true) => {}
+                            Ok(false) => println!(
+                                "PPT config updated and will be applied when tuning is enabled\n\
+                                 See: asusctl profile tuning --help"
+                            ),
+                            Err(e) => {
+                                println!(
+                                    "PPT config updated, but tuning state is unknown: {e}\n\
+                                    See: asusctl profile tuning --help"
+                                )
+                            }
+                        }
+                    }
+
                     print_firmware_attr(attr)?;
                     found = true;
                 }

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -834,6 +834,19 @@ fn handle_throttle_profile(
             println!("AC profile {:?}", proxy.platform_profile_on_ac()?);
             println!("Battery profile {:?}", proxy.platform_profile_on_battery()?);
         }
+        crate::cli_opts::ProfileSubCommand::Tuning(t) => match t.enable {
+            Some(true) => {
+                proxy.set_enable_ppt_group(true)?;
+                println!("Profile tuning enabled")
+            }
+            Some(false) => {
+                proxy.set_enable_ppt_group(false)?;
+                println!("Profile tuning disabled")
+            }
+            None => {
+                println!("Profile tuning: {}", proxy.enable_ppt_group()?)
+            }
+        },
     }
 
     Ok(())

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -756,6 +756,26 @@ impl CtrlPlatform {
             .unwrap_or_default();
         let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
 
+        if enable {
+            // On devices that support it, fan curve is required for any writes to PPT.
+            // Future plans involve unifying that mechanism across all devices.
+            // So we just don't allow writing PPT without fan curve enabled (if device supports it).
+            if let Some(ref fc_config) = self.fan_curve_config {
+                let fc = fc_config.lock().await;
+                let curve_active = fc
+                    .profiles
+                    .get_fan_curves_for(profile)
+                    .iter()
+                    .any(|c| c.enabled);
+
+                if !curve_active {
+                    return Err(FdoErr::Failed(
+                        "Custom fan curve is required to enable profile tuning".to_string(),
+                    ));
+                }
+            }
+        }
+
         // Update config and persist BEFORE any kernel calls that trigger the
         // platform profile watcher, otherwise the watcher races us and reads
         // stale `enabled` state.

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -747,36 +747,6 @@ pub fn setup_system_page_callbacks(ui: &MainWindow, _states: Arc<Mutex<Config>>)
                             FirmwareAttribute::ApuMem => {}
                             FirmwareAttribute::CoresPerformance => {}
                             FirmwareAttribute::CoresEfficiency => {}
-                            FirmwareAttribute::PptEnabled => {
-                                init_property!(ppt_enabled, handle, value, bool);
-                                setup_callback!(ppt_enabled, handle, attr, bool);
-                                let handle_copy = handle.as_weak();
-                                let proxy_copy = attr.clone();
-                                tokio::spawn(async move {
-                                    let mut x = proxy_copy.receive_current_value_changed().await;
-                                    use futures_util::StreamExt;
-                                    while let Some(e) = x.next().await {
-                                        if let Ok(out) = e.get().await {
-                                            handle_copy
-                                                .upgrade_in_event_loop(move |handle| {
-                                                    handle
-                                                        .global::<SystemPageData>()
-                                                        .set_enable_ppt_group(out == 1);
-                                                    handle
-                                                        .global::<SystemPageData>()
-                                                        .set_ppt_enabled(out == 1);
-                                                })
-                                                .ok();
-                                        }
-                                    }
-                                });
-                                handle
-                                    .global::<SystemPageData>()
-                                    .set_ppt_enabled_available(true);
-                                handle
-                                    .global::<SystemPageData>()
-                                    .set_enable_ppt_group(value == 1);
-                            }
                             FirmwareAttribute::PptPl1Spl => {
                                 init_minmax_property!(ppt_pl1_spl, handle, attr);
                                 setup_callback!(ppt_pl1_spl, handle, attr, i32);

--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -402,7 +402,6 @@ pub enum FirmwareAttribute {
     GpuMuxMode = 21,
     MiniLedMode = 22,
     PendingReboot = 23,
-    PptEnabled = 24,
     None = 25,
     ScreenAutoBrightness = 26,
 }
@@ -413,7 +412,6 @@ impl From<&str> for FirmwareAttribute {
             "apu_mem" => Self::ApuMem,
             "cores_performance" => Self::CoresPerformance,
             "cores_efficiency" => Self::CoresEfficiency,
-            "ppt_enabled" => Self::PptEnabled,
             "ppt_pl1_spl" => Self::PptPl1Spl,
             "ppt_pl2_sppt" => Self::PptPl2Sppt,
             "ppt_pl3_fppt" => Self::PptPl3Fppt,
@@ -450,7 +448,6 @@ impl From<FirmwareAttribute> for &str {
             FirmwareAttribute::ApuMem => "apu_mem",
             FirmwareAttribute::CoresPerformance => "cores_performance",
             FirmwareAttribute::CoresEfficiency => "cores_efficiency",
-            FirmwareAttribute::PptEnabled => "ppt_enabled",
             FirmwareAttribute::PptPl1Spl => "ppt_pl1_spl",
             FirmwareAttribute::PptPl2Sppt => "ppt_pl2_sppt",
             FirmwareAttribute::PptPl3Fppt => "ppt_pl3_fppt",


### PR DESCRIPTION
# Description

Introduces new PPT tuning enable feature to asusctl CLI. 
Fixes issue with PPT writes via `asusctl armoury` silently being dropped when tuning is not enabled.
Gates `set_enable_ppt_group` behind active fan curve (rogcc did this but was skipped backend).
Show that PPT is deferred when setting PPT via `asusctl armoury` is tuning is disabled.

Supersedes #150
Fixes #149

## Tested Hardware & Environment

- **ASUS Laptop Model:** ASUS ROG STRIX Scar 18 2025 (G835LW)
- **Linux Distribution:** Arch Linux
- **Kernel Version:** 7.1.5-arch1-2

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
