### PR TITLE
asusd: open scsi_generic /dev/sgN for SCSI Aura devices

### DIFF
--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -276,6 +276,31 @@ impl DeviceManager {
         Ok(devices)
     }
 
+    /// Resolve the `/dev/sgN` (scsi_generic) node backing a block device.
+    ///
+    /// Walks up from the block device to its owning scsi_device and reads the
+    /// `scsi_generic/sgN` child. Works for whole-disk (`/dev/sda`) and
+    /// partition (`/dev/sda1`) nodes alike, since the scsi_device is a common
+    /// ancestor. Returns None if no sg node exists (e.g. the `sg` module is
+    /// not loaded).
+    fn sg_node_for_block(device: &Device) -> Option<String> {
+        let mut current = device.parent();
+        while let Some(d) = current {
+            if let Ok(entries) = std::fs::read_dir(d.syspath().join("scsi_generic")) {
+                for entry in entries.flatten() {
+                    if let Some(name) = entry.file_name().to_str() {
+                        let node = format!("/dev/{name}");
+                        if std::path::Path::new(&node).exists() {
+                            return Some(node);
+                        }
+                    }
+                }
+            }
+            current = d.parent();
+        }
+        None
+    }
+
     async fn init_scsi(
         connection: &Connection,
         device: &Device,
@@ -289,8 +314,40 @@ impl DeviceManager {
                     .property_value("ID_MODEL_ID")
                     .unwrap_or_default()
                     .to_string_lossy();
-                if let Some(dev_str) = dev_node.as_os_str().to_str() {
-                    if let Ok(dev_type) = DeviceHandle::maybe_scsi(dev_str, &prod_id).await {
+                // SG_IO with vendor commands on the block node (/dev/sdX)
+                // requires CAP_SYS_RAWIO, which the hardened asusd unit drops
+                // (every ioctl EPERMs and is silently swallowed by write_effect).
+                // The scsi_generic /dev/sgN node gates access at open() via
+                // file permissions instead, so it works with no capabilities,
+                // the same path sg3_utils / OpenRGB use.
+                //
+                // On hotplug the sg node can appear just after the block node,
+                // so retry briefly before falling back to the block device
+                // (which would EPERM). At startup the node already exists, so
+                // the first attempt succeeds with no delay.
+                let mut sg_node = None;
+                for attempt in 0..8u8 {
+                    if let Some(sg) = Self::sg_node_for_block(device) {
+                        sg_node = Some(sg);
+                        break;
+                    }
+                    if attempt < 7 {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    }
+                }
+                let dev_str = match sg_node {
+                    Some(sg) => Some(sg),
+                    None => {
+                        warn!(
+                            "No /dev/sgN for SCSI device after retries; falling back to block \
+                             node {:?} (SG_IO will EPERM unless asusd has CAP_SYS_RAWIO)",
+                            dev_node
+                        );
+                        dev_node.as_os_str().to_str().map(|s| s.to_string())
+                    }
+                };
+                if let Some(dev_str) = dev_str {
+                    if let Ok(dev_type) = DeviceHandle::maybe_scsi(&dev_str, &prod_id).await {
                         if let DeviceHandle::Scsi(scsi) = dev_type.clone() {
                             let ctrl = ScsiZbus::new(scsi);
                             if ctrl

--- a/asusd/src/aura_scsi/mod.rs
+++ b/asusd/src/aura_scsi/mod.rs
@@ -27,7 +27,12 @@ impl ScsiAura {
     pub async fn write_effect(&self, effect: &AuraEffect) -> Result<(), RogError> {
         let mut tasks: Vec<Task> = effect.into();
         for task in &mut tasks {
-            self.device.lock().await.perform(task).ok();
+            // Surface the ioctl errno instead of dropping it — an EPERM/EIO
+            // here was previously invisible, so asusd reported success while
+            // no SCSI traffic ever reached the device.
+            if let Err(e) = self.device.lock().await.perform(task) {
+                log::warn!("SCSI perform failed: {e}");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
SCSI Aura devices (e.g. ROG STRIX Arion, `0b05:1932`) showed up on D-Bus and `asusctl scsi` reported success, but no traffic ever reached the enclosure. The LEDs never changed.

`write_effect()` opened the block node (`/dev/sdX`) and issued `SG_IO` with the vendor CDB. SG_IO with a vendor command on a block node requires `CAP_SYS_RAWIO`, but the hardened asusd unit strips every capability (empty `CapabilityBoundingSet`, `NoNewPrivileges=true`), so every ioctl returned `EPERM`. `write_effect()` then did `perform(task).ok()` and threw the error away, so asusd reported success while zero commands hit the wire. strace showed `ioctl(N, SG_IO, ...) = -1 EPERM` sixteen times per write, and usbmon showed only baseline usb-storage traffic.

Fix: resolve the `scsi_generic` node (`/dev/sgN`) backing the block device and open that instead. The sg driver gates access at `open()` through the file permissions, so SG_IO works with no capabilities, the same path sg3_utils and OpenRGB use. I also stopped swallowing the ioctl error in `write_effect` so this can't go silent again.

Verified on an Arion: 16/16 SG_IO return 0, the ENE vendor CDBs (mode `0x8021`, colour registers `0x8160+`, apply `0x80a0`) show up in usbmon, and the LEDs change.

Two files, no kernel changes. This is the working userspace reference for the SCSI device-handler driver we discussed.

On hotplug the sg node can lag the block node by a moment, so init retries briefly before falling back to the block device; at startup the node already exists, so the first attempt hits with no delay.
