### PR TITLE
fix(asusd): log unsupported armoury attributes once with attribute name

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use config_traits::StdConfig;
@@ -38,6 +39,7 @@ pub struct AsusArmouryAttribute {
     /// platform control required here for access to PPD or Throttle profile
     platform: RogPlatform,
     power: AsusPower,
+    logged_read_error: Arc<AtomicBool>,
 }
 
 impl AsusArmouryAttribute {
@@ -54,6 +56,7 @@ impl AsusArmouryAttribute {
             queued_gpu,
             platform,
             power,
+            logged_read_error: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -285,13 +288,20 @@ impl AsusArmouryAttribute {
         if !matches!(self.attr.possible_values(), AttrValue::None) {
             attrs.push("possible_values".to_string());
         }
-        // TODO: Don't unwrap, use error
-        if let Ok(value) = self.attr.current_value().map_err(|e| {
-            error!("Failed to read: {e:?}");
-            e
-        }) {
-            if !matches!(value, AttrValue::None) {
-                attrs.push("current_value".to_string());
+        match self.attr.current_value() {
+            Ok(value) => {
+                self.logged_read_error.store(false, Ordering::Relaxed);
+                if matches!(value, AttrValue::Integer(_)) {
+                    attrs.push("current_value".to_string());
+                }
+            }
+            Err(e) => {
+                if !self.logged_read_error.swap(true, Ordering::Relaxed) {
+                    error!(
+                        "Firmware attribute '{}' is not supported or failed to read: {e:?}",
+                        self.attr.name()
+                    );
+                }
             }
         }
         attrs
@@ -403,8 +413,11 @@ impl AsusArmouryAttribute {
         }
         */
 
-        if let Ok(AttrValue::Integer(i)) = self.attr.current_value() {
-            return Ok(i);
+        if let Ok(value) = self.attr.current_value() {
+            self.logged_read_error.store(false, Ordering::Relaxed);
+            if let AttrValue::Integer(i) = value {
+                return Ok(i);
+            }
         }
         Err(fdo::Error::Failed(
             "Could not read current value".to_string(),


### PR DESCRIPTION
# Description

Journald tends to be spammed with errors when a device is not supported on kernel with these lines

`asusd[976]: [ERROR asusd::asus_armoury] Failed to read: Io(Os { code: 19, kind: Uncategorized, message: "No such device" })`

On my laptop they can appear up to 80 times in 5 seconds, making the journalctl really messy.

With this little change we can log if an advice was already logged in the journal, suppressing the 2nd, 3rd, etc etc spawn and logging which error spawned it, like for eg `nv_dynamic_boost` or `ppt_pl3_fppt`

Fixes # N/A

## Tested Hardware & Environment

- **ASUS Laptop Model: ROG Strix G614PR**
- **Linux Distribution: CachyOS**
- **Kernel Version: 7.1.5-cachyos-eevdf**

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
