### PR TITLE
feat: add GU502GV aura support

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -963,6 +963,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "GU502GV",
+        product_id: "",
+        layout_name: "gx502",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Star, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash],
+        basic_zones: [],
+        advanced_type: PerKey,
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "GU502L",
         product_id: "",
         layout_name: "gx502",


### PR DESCRIPTION
adds aura_support.ron for GU502GV. Identical to GU502GU other than increased storage and RTX 2060 over GTX 1660.