### PR TITLE
fix(asusctl): dynamically resolve D-Bus object path for Slash and XGM LED interfaces

### DIFF
--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -13,6 +13,7 @@ use rog_anime::{AnimTime, AnimeDataBuffer, AnimeDiagonal, AnimeGif, AnimeImage, 
 use rog_aura::keyboard::{AuraPowerState, LaptopAuraPower};
 use rog_aura::{self, AuraEffect, PowerZones};
 use rog_dbus::asus_armoury::AsusArmouryProxyBlocking;
+use rog_dbus::find_iface_blocking;
 use rog_dbus::list_iface_blocking;
 use rog_dbus::scsi_aura::ScsiAuraProxyBlocking;
 use rog_dbus::zbus_anime::AnimeProxyBlocking;
@@ -26,7 +27,6 @@ use rog_profiles::error::ProfileError;
 use rog_scsi::AuraMode;
 use ron::ser::PrettyConfig;
 use scsi_cli::ScsiCommand;
-use zbus::blocking::proxy::ProxyImpl;
 use zbus::blocking::Connection;
 
 use crate::cli_opts::*;
@@ -149,44 +149,6 @@ fn check_service(name: &str) -> bool {
     false
 }
 
-fn find_iface<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::error::Error>>
-where
-    T: ProxyImpl<'static> + From<zbus::Proxy<'static>>,
-{
-    let conn = zbus::blocking::Connection::system()?;
-    let f = zbus::blocking::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/")?;
-    let interfaces = f.get_managed_objects()?;
-    let mut paths = Vec::new();
-    for v in interfaces.iter() {
-        // let o: Vec<zbus::names::OwnedInterfaceName> = v.1.keys().map(|e|
-        // e.to_owned()).collect(); println!("{}, {:?}", v.0, o);
-        for k in v.1.keys() {
-            if k.as_str() == iface_name {
-                // println!("Found {iface_name} device at {}, {}", v.0, k);
-                paths.push(v.0.clone());
-            }
-        }
-    }
-    if paths.len() > 1 {
-        println!("Multiple asusd interfaces devices found");
-    }
-    if !paths.is_empty() {
-        let mut ctrl = Vec::new();
-        paths.sort_by(|a, b| a.cmp(b));
-        for path in paths {
-            ctrl.push(
-                T::builder(&conn)
-                    .path(path.clone())?
-                    .destination("xyz.ljones.Asusd")?
-                    .build()?,
-            );
-        }
-        return Ok(ctrl);
-    }
-
-    Err(format!("Did not find {iface_name}").into())
-}
-
 fn do_parsed(
     parsed: &CliStart,
     supported_interfaces: &[String],
@@ -259,7 +221,7 @@ fn handle_info(
             "Supported Platform Properties:\n{:#?}",
             supported_properties
         );
-        if let Ok(aura) = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura") {
+        if let Ok(aura) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura") {
             // TODO: multiple RGB check
             if let Some(first_aura) = aura.first() {
                 let bright = first_aura.supported_brightness()?;
@@ -286,7 +248,7 @@ fn handle_backlight(cmd: &BacklightCommand) -> Result<(), Box<dyn std::error::Er
         && cmd.screenpad_gamma.is_none()
         && cmd.sync_screenpad_brightness.is_none()
     {
-        let backlights = find_iface::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
+        let backlights = find_iface_blocking::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
         for backlight in backlights {
             println!("Current screenpad settings:");
             println!("  Brightness: {}", backlight.screenpad_brightness()?);
@@ -300,7 +262,7 @@ fn handle_backlight(cmd: &BacklightCommand) -> Result<(), Box<dyn std::error::Er
         return Ok(());
     }
 
-    let backlights = find_iface::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
+    let backlights = find_iface_blocking::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
     for backlight in backlights {
         if let Some(brightness) = cmd.screenpad_brightness {
             backlight.set_screenpad_brightness(brightness)?;
@@ -319,7 +281,7 @@ fn handle_backlight(cmd: &BacklightCommand) -> Result<(), Box<dyn std::error::Er
 }
 
 fn handle_brightness(cmd: &BrightnessCommand) -> Result<(), Box<dyn std::error::Error>> {
-    let Ok(aura_proxies) = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura") else {
+    let Ok(aura_proxies) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura") else {
         println!("No aura interface found");
         return Ok(());
     };
@@ -374,7 +336,7 @@ fn handle_anime(cmd: &AnimeCommand) -> Result<(), Box<dyn std::error::Error>> {
         println!("Missing arg or command; run 'asusctl anime --help' for usage");
     }
 
-    let animes = find_iface::<AnimeProxyBlocking>("xyz.ljones.Anime").map_err(|e| {
+    let animes = find_iface_blocking::<AnimeProxyBlocking>("xyz.ljones.Anime").map_err(|e| {
         error!("Did not find any interface for xyz.ljones.Anime: {e:?}");
         e
     })?;
@@ -557,7 +519,7 @@ fn handle_scsi(cmd: &ScsiCommand) -> Result<(), Box<dyn std::error::Error>> {
         println!("Missing arg or command; run 'asusctl scsi --help' for usage");
     }
 
-    let scsis = find_iface::<ScsiAuraProxyBlocking>("xyz.ljones.ScsiAura")?;
+    let scsis = find_iface_blocking::<ScsiAuraProxyBlocking>("xyz.ljones.ScsiAura")?;
 
     for scsi in scsis {
         if let Some(enable) = cmd.enable {
@@ -621,7 +583,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
     if mode.command.is_none() && !mode.prev_mode && !mode.next_mode {
         println!("Missing arg or command; run 'asusctl aura --help' for usage");
         // print available modes when possible
-        if let Ok(aura) = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura") {
+        if let Ok(aura) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura") {
             if let Some(first_aura) = aura.first() {
                 let modes = first_aura.supported_basic_modes()?;
                 println!("Available modes:");
@@ -637,7 +599,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
         println!("Please specify either next or previous");
         return Ok(());
     }
-    let aura = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
     if mode.next_mode {
         for aura in aura {
             let mode = aura.led_mode()?;
@@ -678,7 +640,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
 }
 
 fn handle_led_power1(power: &LedPowerCommand1) -> Result<(), Box<dyn std::error::Error>> {
-    let aura = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
     for aura in aura {
         let dev_type = aura.device_type()?;
         if !dev_type.is_old_laptop() && !dev_type.is_tuf_laptop() {
@@ -735,7 +697,7 @@ fn handle_led_power_1_do_1866(
 }
 
 fn handle_led_power2(power: &LedPowerCommand2) -> Result<(), Box<dyn std::error::Error>> {
-    let aura = find_iface::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
     for aura in aura {
         let dev_type = aura.device_type()?;
         if !dev_type.is_new_laptop() {
@@ -1031,7 +993,9 @@ fn handle_armoury_command(
     // If nested subcommand provided, handle set/get/list.
     match &cmd.command {
         ArmourySubCommand::List(_) => {
-            if let Ok(attrs) = find_iface::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury") {
+            if let Ok(attrs) =
+                find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
+            {
                 for attr in attrs.iter() {
                     print_firmware_attr(attr)?;
                 }
@@ -1040,7 +1004,7 @@ fn handle_armoury_command(
         }
         ArmourySubCommand::Get(g) => {
             let mut found = false;
-            let attrs = find_iface::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
+            let attrs = find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
                 .map_err(|e| format!("Could not reach asusd armoury interface: {e}"))?;
             for attr in attrs.iter() {
                 let name = attr.name()?;
@@ -1056,7 +1020,7 @@ fn handle_armoury_command(
         }
         ArmourySubCommand::Set(s) => {
             let mut found = false;
-            let attrs = find_iface::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
+            let attrs = find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
                 .map_err(|e| format!("Could not reach asusd armoury interface: {e}"))?;
             for attr in attrs.iter() {
                 let name = attr.name()?;

--- a/asusctl/src/slash_cli.rs
+++ b/asusctl/src/slash_cli.rs
@@ -1,7 +1,7 @@
 use argh::FromArgs;
+use rog_dbus::find_iface_blocking;
 use rog_dbus::zbus_slash::SlashProxyBlocking;
 use rog_slash::SlashMode;
-use zbus::blocking::Connection;
 
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "slash", description = "slash ledbar commands")]
@@ -79,73 +79,72 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
         && !cmd.disable
     {
         println!("Missing arg; run 'asusctl slash set --help' for usage");
+        return Ok(());
     }
 
-    let conn = Connection::system()?;
-    let proxy = SlashProxyBlocking::new(&conn)
-        .map_err(|e| format!("Failed to connect to Slash interface: {e}"))?;
-
-    if cmd.enable {
-        proxy.set_enabled(true)?;
-    }
-    if cmd.disable {
-        proxy.set_enabled(false)?;
-    }
-    if let Some(brightness) = cmd.brightness {
-        proxy.set_brightness(brightness)?;
-    }
-    if let Some(interval) = cmd.interval {
-        proxy.set_interval(interval)?;
-    }
-    if let Some(slash_mode) = cmd.mode {
-        proxy.set_mode(slash_mode)?;
-    }
-    if let Some(show) = cmd.show_on_boot {
-        proxy.set_show_on_boot(show)?;
-    }
-    if let Some(show) = cmd.show_on_shutdown {
-        proxy.set_show_on_shutdown(show)?;
-    }
-    if let Some(show) = cmd.show_on_sleep {
-        proxy.set_show_on_sleep(show)?;
-    }
-    if let Some(show) = cmd.show_on_battery {
-        proxy.set_show_on_battery(show)?;
-    }
-    if let Some(show) = cmd.show_battery_warning {
-        proxy.set_show_battery_warning(show)?;
+    let slashes = find_iface_blocking::<SlashProxyBlocking>("xyz.ljones.Slash")?;
+    for proxy in &slashes {
+        if cmd.enable {
+            proxy.set_enabled(true)?;
+        }
+        if cmd.disable {
+            proxy.set_enabled(false)?;
+        }
+        if let Some(brightness) = cmd.brightness {
+            proxy.set_brightness(brightness)?;
+        }
+        if let Some(interval) = cmd.interval {
+            proxy.set_interval(interval)?;
+        }
+        if let Some(slash_mode) = cmd.mode {
+            proxy.set_mode(slash_mode)?;
+        }
+        if let Some(show) = cmd.show_on_boot {
+            proxy.set_show_on_boot(show)?;
+        }
+        if let Some(show) = cmd.show_on_shutdown {
+            proxy.set_show_on_shutdown(show)?;
+        }
+        if let Some(show) = cmd.show_on_sleep {
+            proxy.set_show_on_sleep(show)?;
+        }
+        if let Some(show) = cmd.show_on_battery {
+            proxy.set_show_on_battery(show)?;
+        }
+        if let Some(show) = cmd.show_battery_warning {
+            proxy.set_show_battery_warning(show)?;
+        }
     }
 
     Ok(())
 }
 
 pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
-    let conn = Connection::system()?;
-    let proxy = SlashProxyBlocking::new(&conn)
-        .map_err(|e| format!("Failed to connect to Slash interface: {e}"))?;
+    let slashes = find_iface_blocking::<SlashProxyBlocking>("xyz.ljones.Slash")?;
+    for proxy in &slashes {
+        let enabled = proxy.enabled()?;
+        let brightness = proxy.brightness()?;
+        let interval = proxy.interval()?;
+        let mode = proxy.mode()?;
+        let show_on_boot = proxy.show_on_boot()?;
+        let show_on_shutdown = proxy.show_on_shutdown()?;
+        let show_on_sleep = proxy.show_on_sleep()?;
+        let show_on_battery = proxy.show_on_battery()?;
+        let show_battery_warning = proxy.show_battery_warning()?;
 
-    let enabled = proxy.enabled()?;
-    let brightness = proxy.brightness()?;
-    let interval = proxy.interval()?;
-    let mode = proxy.mode()?;
-    let show_on_boot = proxy.show_on_boot()?;
-    let show_on_shutdown = proxy.show_on_shutdown()?;
-    let show_on_sleep = proxy.show_on_sleep()?;
-    let show_on_battery = proxy.show_on_battery()?;
-    let show_battery_warning = proxy.show_battery_warning()?;
-
-    println!(
-        "Slash LED: {}",
-        if enabled { "enabled" } else { "disabled" }
-    );
-    println!("Brightness: {}", brightness);
-    println!("Interval: {}", interval);
-    println!("Mode: {}", mode);
-    println!("Show on boot: {}", show_on_boot);
-    println!("Show on shutdown: {}", show_on_shutdown);
-    println!("Show on sleep: {}", show_on_sleep);
-    println!("Show on battery: {}", show_on_battery);
-    println!("Show battery warning: {}", show_battery_warning);
+        println!(
+            "Slash LED: {}",
+            if enabled { "enabled" } else { "disabled" }
+        );
+        println!("Brightness: {}", brightness);
+        println!("Interval: {}", interval);
+        println!("Mode: {}", mode);
+        println!("Show on boot: {}", show_on_boot);
+        println!("Show on shutdown: {}", show_on_shutdown);
+        println!("Show on sleep: {}", show_on_sleep);
+        println!("Show on battery: {}", show_on_battery);
+        println!("Show battery warning: {}", show_battery_warning);
+    }
 
     Ok(())
 }

--- a/asusctl/src/xgm_led_cli.rs
+++ b/asusctl/src/xgm_led_cli.rs
@@ -1,22 +1,24 @@
 use crate::cli_opts::XgmLedSubCommand;
+use rog_dbus::find_iface_blocking;
 use rog_dbus::zbus_xgm_led::XgmLedProxyBlocking;
 
 pub fn handle_xgm_led(cmd: &XgmLedSubCommand) -> Result<(), Box<dyn std::error::Error>> {
-    let proxy = XgmLedProxyBlocking::new(&zbus::blocking::Connection::system()?)
-        .map_err(|e| format!("Failed to connect to XG Mobile LED interface: {e}"))?;
+    let xgm_leds = find_iface_blocking::<XgmLedProxyBlocking>("xyz.ljones.XgmLed")?;
 
-    match cmd {
-        XgmLedSubCommand::Get(_) => {
-            let enabled = proxy.xgm_led_enabled()?;
-            println!("XG Mobile LED: {}", if enabled { "ON" } else { "OFF" });
-        }
-        XgmLedSubCommand::Set(cmd) => {
-            let enabled = cmd.value != 0;
-            proxy.set_xgm_led_enabled(enabled)?;
-            println!(
-                "XG Mobile LED set to {}",
-                if enabled { "ON" } else { "OFF" }
-            );
+    for proxy in &xgm_leds {
+        match cmd {
+            XgmLedSubCommand::Get(_) => {
+                let enabled = proxy.xgm_led_enabled()?;
+                println!("XG Mobile LED: {}", if enabled { "ON" } else { "OFF" });
+            }
+            XgmLedSubCommand::Set(cmd) => {
+                let enabled = cmd.value != 0;
+                proxy.set_xgm_led_enabled(enabled)?;
+                println!(
+                    "XG Mobile LED set to {}",
+                    if enabled { "ON" } else { "OFF" }
+                );
+            }
         }
     }
 

--- a/rog-dbus/Cargo.toml
+++ b/rog-dbus/Cargo.toml
@@ -18,4 +18,5 @@ rog_aura = { path = "../rog-aura" }
 rog_profiles = { path = "../rog-profiles" }
 rog_platform = { path = "../rog-platform" }
 zbus.workspace = true
+log.workspace = true
 

--- a/rog-dbus/src/lib.rs
+++ b/rog-dbus/src/lib.rs
@@ -23,6 +23,8 @@ pub fn list_iface_blocking() -> Result<Vec<String>, Box<dyn std::error::Error>> 
             ifaces.push(k.to_string());
         }
     }
+    ifaces.sort();
+    ifaces.dedup();
     Ok(ifaces)
 }
 
@@ -73,7 +75,7 @@ where
         }
     }
     if paths.len() > 1 {
-        println!("Multiple asusd interfaces devices found");
+        log::warn!("Multiple asusd interfaces devices found");
     }
     if !paths.is_empty() {
         let mut ctrl = Vec::new();
@@ -85,6 +87,41 @@ where
                     .destination("xyz.ljones.Asusd")?
                     .build()
                     .await?,
+            );
+        }
+        return Ok(ctrl);
+    }
+
+    Err(format!("Did not find {iface_name}").into())
+}
+
+pub fn find_iface_blocking<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::error::Error>>
+where
+    T: zbus::blocking::proxy::ProxyImpl<'static> + From<zbus::Proxy<'static>>,
+{
+    let conn = zbus::blocking::Connection::system()?;
+    let f = zbus::blocking::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/")?;
+    let interfaces = f.get_managed_objects()?;
+    let mut paths = Vec::new();
+    for v in interfaces.iter() {
+        for k in v.1.keys() {
+            if k.as_str() == iface_name {
+                paths.push(v.0.clone());
+            }
+        }
+    }
+    if paths.len() > 1 {
+        log::warn!("Multiple asusd interfaces devices found");
+    }
+    if !paths.is_empty() {
+        let mut ctrl = Vec::new();
+        paths.sort_by(|a, b| a.cmp(b));
+        for path in paths {
+            ctrl.push(
+                T::builder(&conn)
+                    .path(path.clone())?
+                    .destination("xyz.ljones.Asusd")?
+                    .build()?,
             );
         }
         return Ok(ctrl);


### PR DESCRIPTION
# Description
Fixes an unhandled D-Bus `UnknownInterface: Unknown interface 'xyz.ljones.Slash'` error when executing `asusctl slash set` or `asusctl slash get`.
Previously, `slash_cli.rs` and `xgm_led_cli.rs` used static proxy initialization (`SlashProxyBlocking::new(&conn)`), which directed D-Bus method calls to a hardcoded default path (`/xyz/ljones`). However, `asusd` exports `SlashZbus` dynamically under `/org/asuslinux/aura/slash` via D-Bus `ObjectManager`. This caused `asusctl slash` commands to fail even on supported hardware models with Slash lighting (e.g. ROG Zephyrus G14 `GA403`), whereas `rog-control-center` succeeded because it resolved the object path dynamically using `find_iface_async`.
### Summary of Changes:
- Added `find_iface_blocking<T>(iface_name: &str)` helper function to `rog-dbus` (synchronous counterpart to `find_iface_async`).
- Updated `slash_cli.rs` and `xgm_led_cli.rs` to resolve proxy object paths dynamically via `find_iface_blocking`.
- Removed redundant local `find_iface` helper in `asusctl/src/main.rs`.
- Replaced internal library `println!` logs with structured `log::warn!`.
- Added deduplication and sorting to `list_iface_blocking()`.
Fixes N/A
## Tested Hardware & Environment N/A
# Verification and testing:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)

Closes: #269 