### PR TITLE
Add Aura support for ROG Strix G16 G614PM

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -369,6 +369,15 @@
         power_zones: [Keyboard, Lightbar, Logo],
     ),
     (
+        device_name: "G614PM",
+        product_id: "19b6",
+        layout_name: "g634j-per-key",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Star, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash],
+        basic_zones: [],
+        advanced_type: PerKey,
+        power_zones: [Keyboard, Lightbar, Logo],
+    ),
+    (
         device_name: "G614FR",
         product_id: "",
         layout_name: "g634j-per-key",


### PR DESCRIPTION
  G614PM shares the same Aura hardware ID (19b6) as G614FM but had no
  device_name entry in aura_support.ron, causing asusd to fall back to a
  default profile with no Lightbar/Logo zone support. Duplicated the
  G614FM entry under G614PM's name.

  Tested on hardware: keyboard, lightbar, and logo zones all respond
  correctly to basic effects (static, rainbow-cycle, etc.) in sync.
