### PR TITLE
fix(asusd): carry Slash display mode as u8 over the D-Bus stack

### DIFF
--- a/asusctl/src/slash_cli.rs
+++ b/asusctl/src/slash_cli.rs
@@ -125,7 +125,13 @@ pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
         let enabled = proxy.enabled()?;
         let brightness = proxy.brightness()?;
         let interval = proxy.interval()?;
-        let mode = proxy.mode()?;
+        let mode_raw = proxy.mode()?;
+        let mode_name = SlashMode::try_from(mode_raw)
+            .map(|m| m.to_string())
+            .unwrap_or_else(|e| {
+                log::warn!("Unknown slash mode byte 0x{mode_raw:02x}: {e}");
+                format!("unknown(0x{mode_raw:02x})")
+            });
         let show_on_boot = proxy.show_on_boot()?;
         let show_on_shutdown = proxy.show_on_shutdown()?;
         let show_on_sleep = proxy.show_on_sleep()?;
@@ -138,7 +144,7 @@ pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
         );
         println!("Brightness: {}", brightness);
         println!("Interval: {}", interval);
-        println!("Mode: {}", mode);
+        println!("Mode: {}", mode_name);
         println!("Show on boot: {}", show_on_boot);
         println!("Show on shutdown: {}", show_on_shutdown);
         println!("Show on sleep: {}", show_on_sleep);

--- a/asusctl/src/slash_cli.rs
+++ b/asusctl/src/slash_cli.rs
@@ -97,7 +97,7 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
             proxy.set_interval(interval)?;
         }
         if let Some(slash_mode) = cmd.mode {
-            proxy.set_mode(slash_mode)?;
+            proxy.set_mode(slash_mode as u8)?;
         }
         if let Some(show) = cmd.show_on_boot {
             proxy.set_show_on_boot(show)?;

--- a/asusd/src/aura_slash/trait_impls.rs
+++ b/asusd/src/aura_slash/trait_impls.rs
@@ -140,7 +140,7 @@ impl SlashZbus {
     #[zbus(property)]
     async fn mode(&self) -> zbus::fdo::Result<u8> {
         let config = self.0.lock_config().await;
-        Ok(config.display_interval)
+        Ok(config.display_mode as u8)
     }
 
     /// Set interval between slash animations (0-255)

--- a/asusd/src/aura_slash/trait_impls.rs
+++ b/asusd/src/aura_slash/trait_impls.rs
@@ -145,7 +145,10 @@ impl SlashZbus {
 
     /// Set interval between slash animations (0-255)
     #[zbus(property)]
-    async fn set_mode(&self, mode: SlashMode) -> zbus::Result<()> {
+    async fn set_mode(&self, mode: u8) -> zbus::Result<()> {
+        let mode = SlashMode::try_from(mode).map_err(|err| {
+            zbus::fdo::Error::InvalidArgs(format!("ctrl_slash::set_mode {}", err))
+        })?;
         let mut config = self.0.lock_config().await;
 
         let command_packets = slash_pkt_set_mode(config.slash_type, mode);

--- a/rog-control-center/src/ui/setup_slash.rs
+++ b/rog-control-center/src/ui/setup_slash.rs
@@ -54,8 +54,32 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
             set_ui_props_async!(handle, slash, SlashPageData, show_battery_warning);
             set_ui_props_async!(handle, slash, SlashPageData, show_on_lid_closed);
 
-            if let Ok(mode) = slash.mode().await {
-                let idx = slash_mode_to_index(mode);
+            // Read the persisted mode, retrying once briefly — a single read right
+            // after (re)start can race with asusd and fail. The mode-changed listener
+            // below picks up subsequent changes, but won't recover an initial failure,
+            // so one short retry is kept as a safety net.
+            let mut mode: Option<SlashMode> = None;
+            match slash.mode().await {
+                Ok(raw) => match SlashMode::try_from(raw) {
+                    Ok(m) => mode = Some(m),
+                    Err(e) => log::warn!("slash mode at startup: unknown byte 0x{raw:02x}: {e}"),
+                },
+                Err(e) => {
+                    log::warn!("slash mode unreadable at startup: {e}; retrying once");
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    if let Ok(raw) = slash.mode().await {
+                        match SlashMode::try_from(raw) {
+                            Ok(m) => mode = Some(m),
+                            Err(e) => log::warn!(
+                                "slash mode at startup (retry): unknown byte 0x{raw:02x}: {e}"
+                            ),
+                        }
+                    }
+                }
+            }
+            if let Some(m) = mode {
+                let idx = slash_mode_to_index(m);
+                log::info!("slash mode at startup: {:?} (index {})", m, idx);
                 let choices = slash_modes();
                 handle
                     .upgrade_in_event_loop(move |handle| {
@@ -64,6 +88,8 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                         global.set_mode(idx);
                     })
                     .ok();
+            } else {
+                log::error!("slash mode unreadable after retries; UI will show Static");
             }
 
             handle
@@ -98,13 +124,20 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                         let mut x = slash_copy.receive_mode_changed().await;
                         use futures_util::StreamExt;
                         while let Some(e) = x.next().await {
-                            if let Ok(out) = e.get().await {
-                                let idx = slash_mode_to_index(out);
-                                handle_copy
-                                    .upgrade_in_event_loop(move |handle| {
-                                        handle.global::<SlashPageData>().set_mode(idx);
-                                    })
-                                    .ok();
+                            if let Ok(raw) = e.get().await {
+                                match SlashMode::try_from(raw) {
+                                    Ok(out) => {
+                                        let idx = slash_mode_to_index(out);
+                                        handle_copy
+                                            .upgrade_in_event_loop(move |handle| {
+                                                handle.global::<SlashPageData>().set_mode(idx);
+                                            })
+                                            .ok();
+                                    }
+                                    Err(e) => log::warn!(
+                                        "setup_slash: received unknown slash mode 0x{raw:02x}: {e}"
+                                    ),
+                                }
                             }
                         }
                     });

--- a/rog-control-center/src/ui/setup_slash.rs
+++ b/rog-control-center/src/ui/setup_slash.rs
@@ -113,7 +113,9 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                                 .into(),
                                 "Setting Slash animation failed".into(),
                                 handle_copy,
-                                slash_copy.set_mode(slash_mode_from_index(index)).await,
+                                slash_copy
+                                    .set_mode(slash_mode_from_index(index) as u8)
+                                    .await,
                             );
                         });
                     });

--- a/rog-dbus/src/zbus_slash.rs
+++ b/rog-dbus/src/zbus_slash.rs
@@ -27,7 +27,7 @@ pub trait Slash {
 
     /// Slash modes property
     #[zbus(property)]
-    fn mode(&self) -> zbus::Result<SlashMode>;
+    fn mode(&self) -> zbus::Result<u8>;
     #[zbus(property)]
     fn set_mode(&self, value: SlashMode) -> zbus::Result<()>;
 

--- a/rog-dbus/src/zbus_slash.rs
+++ b/rog-dbus/src/zbus_slash.rs
@@ -1,4 +1,3 @@
-use rog_slash::SlashMode;
 use zbus::proxy;
 
 #[proxy(
@@ -29,7 +28,7 @@ pub trait Slash {
     #[zbus(property)]
     fn mode(&self) -> zbus::Result<u8>;
     #[zbus(property)]
-    fn set_mode(&self, value: SlashMode) -> zbus::Result<()>;
+    fn set_mode(&self, value: u8) -> zbus::Result<()>;
 
     /// ShowBatteryWarning property
     #[zbus(property)]

--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -95,6 +95,7 @@ impl FromStr for SlashType {
 }
 
 #[cfg_attr(feature = "dbus", derive(Type, Value, OwnedValue))]
+#[repr(u8)]
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
 pub enum SlashMode {
     Static = 0x06,
@@ -138,6 +139,34 @@ impl FromStr for SlashMode {
             "Start" => Ok(SlashMode::Start),
             "Buzzer" => Ok(SlashMode::Buzzer),
             _ => Ok(SlashMode::Bounce),
+        }
+    }
+}
+
+impl TryFrom<u8> for SlashMode {
+    type Error = SlashError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x06 => Ok(SlashMode::Static),
+            0x10 => Ok(SlashMode::Bounce),
+            0x12 => Ok(SlashMode::Slash),
+            0x13 => Ok(SlashMode::Loading),
+            0x1d => Ok(SlashMode::BitStream),
+            0x1a => Ok(SlashMode::Transmission),
+            0x19 => Ok(SlashMode::Flow),
+            0x25 => Ok(SlashMode::Flux),
+            0x24 => Ok(SlashMode::Phantom),
+            0x26 => Ok(SlashMode::Spectrum),
+            0x32 => Ok(SlashMode::Hazard),
+            0x33 => Ok(SlashMode::Interfacing),
+            0x34 => Ok(SlashMode::Ramp),
+            0x42 => Ok(SlashMode::GameOver),
+            0x43 => Ok(SlashMode::Start),
+            0x44 => Ok(SlashMode::Buzzer),
+            _ => Err(SlashError::ParseError(format!(
+                "Unknown SlashMode discriminant: 0x{value:02x}"
+            ))),
         }
     }
 }

--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -95,7 +95,6 @@ impl FromStr for SlashType {
 }
 
 #[cfg_attr(feature = "dbus", derive(Type, Value, OwnedValue))]
-#[repr(u8)]
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
 pub enum SlashMode {
     Static = 0x06,


### PR DESCRIPTION
Split out of #230, where it was buried inside the UI redesign. It is a self-contained backend change and has nothing to do with the UI work, so it gets its own PR.

The Slash display mode was leaking through the D-Bus stack as the raw animation interval, while every caller actually wanted the mode discriminant. Thread it as u8 instead:

- **rog-slash**: `SlashMode` is now `#[repr(u8)]`
- **asusd** trait impl + **rog-dbus** binding return `u8`
- **asusctl** CLI parses `u8`
- **rog-control-center** `setup_slash` consumes `u8`, with a short retry because the single post-startup read races asusd coming up

No UI page is touched. Builds clean across rog-slash / rog-dbus / asusd / asusctl / rog-control-center.