### PR TITLE
fix(rog-control-center): app window default size increased to better …

### DIFF
--- a/rog-control-center/ui/globals.slint
+++ b/rog-control-center/ui/globals.slint
@@ -1,6 +1,6 @@
 export global AppSize {
-    out property <length> width: 900px;
-    out property <length> height: 500px;
+    out property <length> width: 1100px;
+    out property <length> height: 630px;
 }
 
 export global IconImages {


### PR DESCRIPTION
# Description

Increases default `rog-control-center` window size to better fit content.
Before:
<img width="908" height="534" alt="before" src="https://github.com/user-attachments/assets/bf704c33-ef17-4fa8-8679-b5a1e053f1a7" />
After:
<img width="1110" height="665" alt="after" src="https://github.com/user-attachments/assets/8142ab78-8d18-4eca-80b3-20402aa19c14" />

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Strix SCAR 18 G835LX
- **Linux Distribution:** CachyOS (KDE Plasma)
- **Kernel Version:** 7.1.6-1-cachyos