### PR TITLE
feat: add support for ROG Zephyrus G16 GU606AX

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -1044,6 +1044,15 @@
         power_zones: [Keyboard],
     ),
     (
+        device_name: "GU606",
+        product_id: "",
+        layout_name: "ga401q",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Pulse],
+        basic_zones: [],
+        advanced_type: Zoned([SingleZone]),
+        power_zones: [Keyboard],
+    ),
+    (
         device_name: "GV301Q",
         product_id: "",
         layout_name: "ga401q",

--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -18,6 +18,7 @@ pub enum SlashType {
     GA605_2025,
     GU605_2024,
     GU605_2025,
+    GU606_2026,
     G614_2025,
     #[default]
     Unsupported,
@@ -32,6 +33,7 @@ impl SlashType {
             SlashType::GA605_2024 => PROD_ID2,
             SlashType::GU605_2025 => PROD_ID2,
             SlashType::GU605_2024 => PROD_ID1,
+            SlashType::GU606_2026 => PROD_ID2,
             SlashType::G614_2025 => PROD_ID2,
             SlashType::Unsupported => 0,
         }
@@ -45,6 +47,7 @@ impl SlashType {
             SlashType::GA605_2024 => PROD_ID2_STR,
             SlashType::GU605_2025 => PROD_ID2_STR,
             SlashType::GU605_2024 => PROD_ID1_STR,
+            SlashType::GU606_2026 => PROD_ID2_STR,
             SlashType::G614_2025 => PROD_ID2_STR,
             SlashType::Unsupported => "",
         }
@@ -67,6 +70,8 @@ impl SlashType {
             SlashType::GA605_2025
         } else if board_name.contains("GA605") {
             SlashType::GA605_2024
+        } else if board_name.contains("GU606") {
+            SlashType::GU606_2026
         } else if board_name.contains("GU605C") {
             SlashType::GU605_2025
         } else if board_name.contains("GU605") {
@@ -88,6 +93,7 @@ impl FromStr for SlashType {
             "GA605_2024" => Self::GA605_2024,
             "GU605_2025" => Self::GU605_2025,
             "GU605_2024" => Self::GU605_2024,
+            "GU606_2026" => Self::GU606_2026,
             "G614_2025" => Self::G614_2025,
             _ => Self::Unsupported,
         })

--- a/rog-slash/src/usb.rs
+++ b/rog-slash/src/usb.rs
@@ -31,6 +31,7 @@ pub const fn report_id(slash_type: SlashType) -> u8 {
         SlashType::GA605_2024 => REPORT_ID_19B6,
         SlashType::GU605_2025 => REPORT_ID_19B6,
         SlashType::GU605_2024 => REPORT_ID_193B,
+        SlashType::GU606_2026 => REPORT_ID_19B6,
         SlashType::G614_2025 => REPORT_ID_19B6,
         SlashType::Unsupported => REPORT_ID_19B6,
     }


### PR DESCRIPTION
Keyboard aura and lid Slash for the GU606AX. Board name `GU606AX`, aura device `0b05:19b6`.

### Aura

Right now it falls back to the default entry:

```
[WARN rog_aura::aura_detection] the aura_support.ron file has no entry for
this model: GU606AX, 19b6. Using a default
```

which means Static only. Instead of copying the GU605M entry I loaded one with all twelve modes through `asusd_user_ledmodes.ron` and tried each on the keyboard:

- works: Static, Breathe, RainbowCycle, RainbowWave, Pulse
- nothing visible: Star, Rain, Highlight, Laser, Ripple, Comet, Flash

The dead ones are all per-key effects — the keyboard is single-zone so they get accepted but nothing shows. That leaves the same set as GU605M, which is what the entry uses.

### Slash

No GU606 branch in `from_dmi()`, so the ledbar is never picked up:

```
[INFO asusd::aura_types] Unknown or invalid slash: "19b6", skipping
```

Before assuming the GU605 format works I replayed the set-mode packets straight to the hidraw node, plus three variants: with the `0xd2` packet that `set_mode()` builds but never sends, with `0x10` instead of `0x19` in slot 2, and with the mode in slot 0. All four drove the ledbar fine, so the format is already right and only the enum variant and DMI match are needed.

After that everything works — detection, enable, brightness, all modes:

```
[INFO asusd::aura_types] Found slash type GU606_2026: 19b6
```

### One thing if you test this

asusctl 6.3.11 can't drive Slash here, its CLI uses a fixed D-Bus object path so `slash set --mode` silently does nothing. Not related to this PR, already fixed on main by c47ccea, but a released CLI against a patched daemon looks like the patch is broken. Build the CLI from main.