### PR TITLE
Fix Aura interface selection and effect persistence for GX651AR Zephyrus Duo

### DIFF
--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -137,7 +137,9 @@ impl AuraZbus {
         if config.brightness == LedBrightness::Off {
             config.brightness = LedBrightness::Med;
         }
-        self.0.set_brightness(config.brightness.into()).await?;
+        if let Err(e) = self.0.set_brightness(config.brightness.into()).await {
+            log::warn!("Could not set keyboard backlight brightness: {e}");
+        }
         config.write();
         Ok(())
     }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -179,7 +179,9 @@ impl AuraZbus {
         if config.brightness == LedBrightness::Off {
             config.brightness = LedBrightness::Med;
         }
-        self.0.set_brightness(config.brightness.into()).await?;
+        if let Err(e) = self.0.set_brightness(config.brightness.into()).await {
+            log::warn!("Could not set keyboard backlight brightness: {e}");
+        }
         config.set_builtin(effect);
         config.write();
         Ok(())

--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -100,6 +100,37 @@ pub struct DeviceManager {
     _hid_handles: Arc<Mutex<HashMap<String, Arc<Mutex<HidRaw>>>>>,
 }
 
+/// Returns true if this hidraw device is a non-Aura interface on the
+/// ASUS Zephyrus Duo (0b05:1ce6) composite device and should be skipped.
+///
+/// 0b05:1ce6 exposes multiple HID interfaces; only interface 1.2 is the
+/// real Aura/vendor control interface (report ID 0x5d, Output/Feature
+/// capable). Other interfaces reuse that report ID for unrelated
+/// Input-only data. Used by both startup enumeration and hotplug
+/// add-event handling so the wrong interface can never be selected,
+/// including after USB reset/resume.
+fn is_non_aura_1ce6_interface(device: &Device) -> bool {
+    if let Ok(Some(usb_parent)) = device.parent_with_subsystem_devtype("usb", "usb_device") {
+        let vendor = usb_parent.attribute_value("idVendor");
+        let product = usb_parent.attribute_value("idProduct");
+
+        if vendor == Some(std::ffi::OsStr::new("0b05"))
+            && product == Some(std::ffi::OsStr::new("1ce6"))
+        {
+            let syspath = device.syspath().to_string_lossy().to_string();
+            if !syspath.contains(":1.2/") {
+                debug!("Skipping non-Aura 1ce6 HID interface: {}", syspath);
+                return true;
+            }
+            debug!(
+                "Selected ASUS 0b05:1ce6 Aura HID interface 1.2: {}",
+                syspath
+            );
+        }
+    }
+    false
+}
+
 impl DeviceManager {
     #[allow(clippy::type_complexity)]
     async fn get_or_create_hid_handle(
@@ -259,44 +290,18 @@ impl DeviceManager {
             .scan_devices()
             .map_err(|e| PlatformError::IoPath("enumerator".to_owned(), e))?
         {
-            // ASUS Zephyrus Duo keyboard 0b05:1ce6 is a composite HID device.
-            //
-            // Interface 0 is the normal keyboard HID, while the Aura/vendor
-            // control interface is interface 1.2 (hidraw3 was the current node
-            // at time of writing, but hidraw numbering is not stable).
-            //
-            // Do not let interface 0 win merely because udev enumerates it first.
-            // For 1ce6, only process the vendor-specific interface (1.2).
+            // ASUS Zephyrus Duo keyboard 0b05:1ce6 is a composite HID device;
+            // see is_non_aura_1ce6_interface for why interface 1.2 is required.
+            if is_non_aura_1ce6_interface(&device) {
+                continue;
+            }
+
             if let Ok(Some(usb_parent)) = device.parent_with_subsystem_devtype("usb", "usb_device")
             {
-                let vendor = usb_parent.attribute_value("idVendor");
-                let product = usb_parent.attribute_value("idProduct");
-
-                if vendor == Some(std::ffi::OsStr::new("0b05"))
-                    && product == Some(std::ffi::OsStr::new("1ce6"))
-                {
-                    let syspath = device.syspath().to_string_lossy().to_string();
-
-                    if !syspath.contains(":1.2/") {
-                        debug!("Skipping non-Aura 1ce6 HID interface: {}", syspath);
-                        continue;
-                    }
-
-                    debug!(
-                        "Selected ASUS 0b05:1ce6 Aura HID interface 1.2: {}",
-                        syspath
-                    );
-
-                    if !seen_usb_parents.insert(syspath) {
-                        continue;
-                    }
-                } else if vendor == Some(std::ffi::OsStr::new("0b05")) {
-                    let parent_path = usb_parent.syspath().to_string_lossy().to_string();
-
-                    if !seen_usb_parents.insert(parent_path) {
-                        debug!("Skipping duplicate ASUS hidraw for USB parent already processed");
-                        continue;
-                    }
+                let parent_path = usb_parent.syspath().to_string_lossy().to_string();
+                if !seen_usb_parents.insert(parent_path) {
+                    debug!("Skipping duplicate ASUS hidraw for USB parent already processed");
+                    continue;
                 }
             }
 
@@ -687,6 +692,9 @@ impl DeviceManager {
                                         }
                                     }
                                     let evdev = event.device();
+                                    if is_non_aura_1ce6_interface(&evdev) {
+                                        return Ok(());
+                                    }
                                     if let Ok(mut new_devs) = Self::init_hid_devices(
                                         &conn_copy,
                                         evdev,

--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -259,17 +259,46 @@ impl DeviceManager {
             .scan_devices()
             .map_err(|e| PlatformError::IoPath("enumerator".to_owned(), e))?
         {
-            // Only deduplicate ASUS devices; non-ASUS multi-interface devices are unaffected.
+            // ASUS Zephyrus Duo keyboard 0b05:1ce6 is a composite HID device.
+            //
+            // Interface 0 is the normal keyboard HID, while the Aura/vendor
+            // control interface is interface 3 (hidraw3 on the current GX651AR).
+            //
+            // Do not let interface 0 win merely because udev enumerates it first.
+            // For 1ce6, only process the vendor-specific interface (1.3).
             if let Ok(Some(usb_parent)) = device.parent_with_subsystem_devtype("usb", "usb_device")
             {
-                if usb_parent.attribute_value("idVendor") == Some(std::ffi::OsStr::new("0b05")) {
-                    let syspath = usb_parent.syspath().to_string_lossy().to_string();
+                let vendor = usb_parent.attribute_value("idVendor");
+                let product = usb_parent.attribute_value("idProduct");
+
+                if vendor == Some(std::ffi::OsStr::new("0b05"))
+                    && product == Some(std::ffi::OsStr::new("1ce6"))
+                {
+                    let syspath = device.syspath().to_string_lossy().to_string();
+
+                    if !syspath.contains(":1.2/") {
+                        debug!("Skipping non-Aura 1ce6 HID interface: {}", syspath);
+                        continue;
+                    }
+
+                    debug!(
+                        "Selected ASUS 0b05:1ce6 Aura HID interface 1.2: {}",
+                        syspath
+                    );
+
                     if !seen_usb_parents.insert(syspath) {
-                        debug!("Skipping duplicate hidraw for USB parent already processed");
+                        continue;
+                    }
+                } else if vendor == Some(std::ffi::OsStr::new("0b05")) {
+                    let parent_path = usb_parent.syspath().to_string_lossy().to_string();
+
+                    if !seen_usb_parents.insert(parent_path) {
+                        debug!("Skipping duplicate ASUS hidraw for USB parent already processed");
                         continue;
                     }
                 }
             }
+
             devices.append(&mut Self::init_hid_devices(connection, device, handles.clone()).await?);
         }
 

--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -262,10 +262,11 @@ impl DeviceManager {
             // ASUS Zephyrus Duo keyboard 0b05:1ce6 is a composite HID device.
             //
             // Interface 0 is the normal keyboard HID, while the Aura/vendor
-            // control interface is interface 3 (hidraw3 on the current GX651AR).
+            // control interface is interface 1.2 (hidraw3 was the current node
+            // at time of writing, but hidraw numbering is not stable).
             //
             // Do not let interface 0 win merely because udev enumerates it first.
-            // For 1ce6, only process the vendor-specific interface (1.3).
+            // For 1ce6, only process the vendor-specific interface (1.2).
             if let Ok(Some(usb_parent)) = device.parent_with_subsystem_devtype("usb", "usb_device")
             {
                 let vendor = usb_parent.attribute_value("idVendor");

--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -1106,14 +1106,14 @@
         advanced_type: r#None,
         power_zones: [Keyboard],
     ),
-        (
+    (
         device_name: "GX651AR",
         product_id: "1ce6",
-        layout_name: "g634j-per-key",
-        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Star, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash],
+        layout_name: "ga401q",
+        basic_modes: [Static, Breathe, RainbowCycle, Pulse],
         basic_zones: [],
-        advanced_type: PerKey,
-        power_zones: [Keyboard, Lightbar],
+        advanced_type: r#None,
+        power_zones: [Keyboard],
     ),
 (
         device_name: "GX502",

--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -1106,7 +1106,16 @@
         advanced_type: r#None,
         power_zones: [Keyboard],
     ),
-    (
+        (
+        device_name: "GX651AR",
+        product_id: "1ce6",
+        layout_name: "g634j-per-key",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Star, Rain, Highlight, Laser, Ripple, Pulse, Comet, Flash],
+        basic_zones: [],
+        advanced_type: PerKey,
+        power_zones: [Keyboard, Lightbar],
+    ),
+(
         device_name: "GX502",
         product_id: "",
         layout_name: "gx502",

--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -1107,15 +1107,6 @@
         power_zones: [Keyboard],
     ),
     (
-        device_name: "GX651AR",
-        product_id: "1ce6",
-        layout_name: "ga401q",
-        basic_modes: [Static, Breathe, RainbowCycle, Pulse],
-        basic_zones: [],
-        advanced_type: r#None,
-        power_zones: [Keyboard],
-    ),
-(
         device_name: "GX502",
         product_id: "",
         layout_name: "gx502",
@@ -1168,6 +1159,15 @@
         basic_zones: [],
         advanced_type: PerKey,
         power_zones: [Keyboard, Lightbar],
+    ),
+    (
+        device_name: "GX651AR",
+        product_id: "1ce6",
+        layout_name: "ga401q",
+        basic_modes: [Static, Breathe, RainbowCycle, Pulse],
+        basic_zones: [],
+        advanced_type: r#None,
+        power_zones: [Keyboard],
     ),
     (
         device_name: "GX701",

--- a/rog-aura/src/keyboard/power.rs
+++ b/rog-aura/src/keyboard/power.rs
@@ -1,5 +1,5 @@
 //! Power state for Laptop MCU RGB/LED. This is generally for newer
-//! 0x18c6, 0x19B6, 0x1a30, keyboard models (2021+)
+//! 0x18c6 | 0x1ce6 | 0x1ce6, 0x19B6, 0x1a30 | 0x1ce6 | 0x1ce6, keyboard models (2021+)
 use std::fmt::Debug;
 use std::ops::{BitAnd, BitOr};
 
@@ -158,7 +158,7 @@ pub struct LaptopAuraPower {
 }
 
 impl LaptopAuraPower {
-    /// # Bits for newer 0x18c6, 0x19B6, 0x1a30, keyboard models
+    /// # Bits for newer 0x18c6 | 0x1ce6 | 0x1ce6, 0x19B6, 0x1a30 | 0x1ce6 | 0x1ce6, keyboard models
     ///
     /// | Byte 1 | Byte 2  | Byte 3  | Byte 4  | Label    |
     /// |--------|---------|---------|---------|----------|

--- a/rog-aura/src/keyboard/power.rs
+++ b/rog-aura/src/keyboard/power.rs
@@ -1,5 +1,5 @@
 //! Power state for Laptop MCU RGB/LED. This is generally for newer
-//! 0x18c6 | 0x1ce6 | 0x1ce6, 0x19B6, 0x1a30 | 0x1ce6 | 0x1ce6, keyboard models (2021+)
+//! 0x18c6, 0x19B6, 0x1a30, 0x1ce6, keyboard models (2021+)
 use std::fmt::Debug;
 use std::ops::{BitAnd, BitOr};
 
@@ -158,7 +158,7 @@ pub struct LaptopAuraPower {
 }
 
 impl LaptopAuraPower {
-    /// # Bits for newer 0x18c6 | 0x1ce6 | 0x1ce6, 0x19B6, 0x1a30 | 0x1ce6 | 0x1ce6, keyboard models
+    /// # Bits for newer 0x18c6, 0x19B6, 0x1a30, 0x1ce6, keyboard models
     ///
     /// | Byte 1 | Byte 2  | Byte 3  | Byte 4  | Label    |
     /// |--------|---------|---------|---------|----------|

--- a/rog-aura/src/lib.rs
+++ b/rog-aura/src/lib.rs
@@ -101,7 +101,7 @@ impl From<&str> for AuraDeviceType {
             "1866" | "18c6" | "1869" | "1854" => Self::LaptopKeyboardPre2021,
             "1abe" | "1b4c" => Self::Ally,
             "19b3" | "193b" => Self::AnimeOrSlash,
-            "19b6" | "1a30" => Self::LaptopKeyboard2021,
+            "19b6" | "1a30" | "1ce6" => Self::LaptopKeyboard2021,
             _ => Self::Unknown,
         }
     }


### PR DESCRIPTION
# Description

The ASUS ROG Zephyrus Duo keyboard (USB ID 0b05:1ce6) had two separate
bugs preventing RGB/Aura control from working.

## Bug 1: Wrong HID interface selected
0b05:1ce6 is a composite HID device exposing multiple interfaces.
DeviceManager was selecting an interface that reuses report ID 0x5d
for unrelated Input-only data (keyboard media keys), rather than the
actual Aura control interface (Output/Feature capable per the HID
report descriptor), which is USB interface 1.2. This caused RGB
commands to silently fail.

## Bug 2: Effect writes silently failed to persist on backlight-less devices
This device has no sysfs keyboard backlight class. `set_led_mode_data`
called `set_brightness()?` immediately after a successful color write;
since that call always fails on this hardware, the `?` aborted the
rest of the function -- including `config.write()`. The color change
was sent to the keyboard and visible immediately, but was never saved,
and asusctl reported an error even though the write had succeeded. On
reboot, the keyboard would revert to whatever was last saved, making
Aura control look completely broken even though the underlying HID
write worked correctly.

Fix: brightness failures are now logged as a warning instead of
aborting the effect-setting flow, so color/effect changes always
persist regardless of whether backlight control is available.

Related to #264

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Zephyrus Duo GX651AR
- **Linux Distribution:** Fedora 44
- **Kernel Version:** 7.1.7-200.fc44.x86_64

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)

Verified working via `asusctl aura effect`, confirmed on real hardware:
- `static -c <colour>`, `breathe --colour <c1> --colour2 <c2> --speed <speed>`,
  `rainbow-cycle --speed <speed>`, `pulse -c <colour>` -- keyboard
  changes color/effect immediately
- Color setting **persists across a full reboot** -- verified by
  setting a color, rebooting with no manual intervention, and
  confirming both the keyboard and `/etc/asusd/aura_*.ron` correctly
  retained the value
- `RainbowWave` was tested and did not produce a visible effect on
  this hardware, so it was intentionally left out of `basic_modes`

## Notes

`layout_name` is currently borrowed from `ga401q` (single-zone default)
since this device doesn't have a dedicated per-key layout file yet.

Keyboard brightness control itself is still not supported on this
hardware (no sysfs LED backlight class) -- querying/setting brightness
specifically will still error, which is expected and unrelated to this
fix. What's fixed is that this limitation no longer breaks color/effect
control or its persistence.