### PR TITLE
fix(asusd): classify charge_mode as ReadOnly and self-heal reload failures

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -613,7 +613,19 @@ pub async fn start_attributes_zbus(
                 "Skipping attribute '{}' due to reload error: {e:?}",
                 attr.attr.name()
             );
-            break;
+            // Self-heal: drop the failing key from persisted config so
+            // successive boots converge instead of accumulating dead
+            // entries that re-trigger the same reload failure. Fixes #132.
+            let key: FirmwareAttribute = attr.attr.name().into();
+            let mut cfg = config.lock().await;
+            if cfg.armoury_settings.remove(&key).is_some() {
+                cfg.write();
+                info!(
+                    "Dropped unappliable persisted value for '{}' after reload error",
+                    attr.attr.name()
+                );
+            }
+            continue;
         }
 
         let attr_name = attr.attribute_name();

--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -352,7 +352,13 @@ define_attribute_getters!(
 
         apu_mem: Norestore,
 
-        charge_mode: Immediate,
+        // charge_mode is kernel-side read-only: the asus-armoury driver
+        // declares it via ASUS_ATTR_GROUP_ENUM_INT_RO and exposes a 0444
+        // sysfs node with no store handler. It is a status mirror of the
+        // firmware's current charging state, not a control. Any write
+        // attempt returns EACCES even as root, and previously that error
+        // aborted attribute registration on the DBus interface (#132).
+        charge_mode: ReadOnly,
     }
 );
 


### PR DESCRIPTION
## Summary

Two-part fix for #132 (asusd fails to register the `xyz.ljones.AsusArmoury` DBus interface when any single attribute's `reload()` fails):

1. **Reclassify `charge_mode` as `ReadOnly`** in `rog-platform`'s `FirmwareAttribute` type table. The upstream `asus-armoury` kernel driver declares this attribute via `ASUS_ATTR_GROUP_ENUM_INT_RO`, exposing a `0444` sysfs node with no `.store` handler — it is a status mirror of the firmware's current charging state, not a control. asusd 6.3.11 classified it as `Immediate` and attempted to write persisted values on startup, producing `EACCES` on every reload. Routing to the existing `ReadOnly` arm (same treatment as `nv_base_tgp`) prevents the write.

2. **`break` → `continue` in `start_attributes_zbus`** with a self-heal step: on reload failure, drop the failing key from `armoury_settings` before continuing. The log message (`"Skipping attribute ... due to reload error"`) and the sibling `move_to_zbus` error handler (`continue`) both indicate this was always the intent. The self-heal addresses the concern that led to the b6c85665 revert of PR #144 (naive `continue` alone would silently accumulate dead config entries).

## Live-hardware verification

**Hardware:** ROG Zephyrus G15 GA503QR (R9-5900HS + RTX 3070, muxless MSHybrid)
**Kernel:** linux-g14 7.1.4-1-g14
**Build:** `cargo build --release --bin asusd`; installed to `/usr/bin/asusd`

### Trigger present when patched asusd started

`/etc/asusd/asusd.ron` was rewritten to contain the failing entry:

```ron
armoury_settings: {
    ChargeMode: 2,
},
```

### Result from patched binary (startup journal)

```
[INFO asusd::asus_armoury] Reloading charge_mode
[INFO asusd::asus_armoury] Removed stale persisted read-only attribute charge_mode from config
[INFO asusd::asus_armoury] Reload called on read-only attribute charge_mode: doing nothing
[INFO asusd::asus_armoury] No saved value for attribute charge_mode: skipping.
[INFO asusd::asus_armoury] Reloading panel_overdrive
[INFO asusd::asus_armoury] Reload called on firmware attribute panel_overdrive
[INFO asusd::asus_armoury] No saved value for attribute panel_overdrive: skipping.
[INFO asusd::asus_armoury] Reloading ppt_pl1_spl / ppt_pl2_sppt / dgpu_disable / boot_sound
  (all succeed cleanly)
[INFO asusd] Startup success on dbus name xyz.ljones.Asusd: begining dbus server loop
```

`grep -iE 'PermissionDenied|Permission denied'` on the startup journal returns **zero** matches.

### DBus tree after startup

```
xyz.ljones.Asusd
└─ /xyz/ljones
    ├─ /xyz/ljones/asus_armoury
    │   ├─ /xyz/ljones/asus_armoury/boot_sound
    │   ├─ /xyz/ljones/asus_armoury/charge_mode
    │   ├─ /xyz/ljones/asus_armoury/dgpu_disable
    │   ├─ /xyz/ljones/asus_armoury/panel_overdrive
    │   ├─ /xyz/ljones/asus_armoury/ppt_pl1_spl
    │   └─ /xyz/ljones/asus_armoury/ppt_pl2_sppt
    └─ /xyz/ljones/aura/19b6_2_3
```

Full interface registered; `dgpu_disable` visible → rog-control-center GPU tab functional.

### asusd.ron auto-cleaned

After the restart, `/etc/asusd/asusd.ron` was rewritten by asusd with `armoury_settings: {}` — the `ChargeMode: 2` entry was purged via the existing ReadOnly arm's cleanup path (line 217-220 in `asusd/src/asus_armoury.rs`). No manual edit; the config self-heals.

### Pre-patch behavior (same trigger, stock 6.3.11)

Same `ChargeMode: 2` in asusd.ron, stock unpatched 6.3.11 binary:

```
[ERROR asusd::asus_armoury] Could not set charge_mode value: Io(Os { code: 13, kind: PermissionDenied })
[ERROR asusd::asus_armoury] Skipping attribute 'charge_mode' due to reload error: Platform(...)
```

DBus tree only shows `/xyz/ljones/aura/…` — `AsusArmoury` interface entirely missing → rog-control-center reports "no switchable GPU" / "asus-armoury driver not loaded" (even though the kernel driver IS loaded).

## What is verified vs. what is code-inspection only

**Verified live on GA503QR:**
- Primary classification fix (part 1) — `charge_mode` is now handled by the ReadOnly arm; no write attempted; DBus interface fully registered; asusd.ron self-cleans via the existing ReadOnly cleanup path (line 217-220).

**Code-inspection only:**
- Secondary `break → continue` + drop-key fix (part 2) — with `charge_mode` reclassified as `ReadOnly`, no attribute's `reload()` returns `Err` on this hardware, so the new code path in `start_attributes_zbus` doesn't fire during this test. It's defensive robustness for future/other-SKU failure modes (e.g., the original `nv_dynamic_boost` EINVAL scenario from #132). Cannot be induced live without patching the kernel driver perms or introducing a synthetic failure mode. Please test on hardware where the original #132 symptom (`nv_dynamic_boost` reject) reproduces if possible.

## Test plan checklist

- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --no-deps` clean
- [x] Live-hardware smoke test on GA503QR / linux-g14 7.1.4 (patched release binary running against `ChargeMode: 2` trigger)
- [x] Pre-patch journal + DBus tree captured for comparison
- [x] Post-patch journal + DBus tree captured
- [x] Config self-heal (asusd.ron auto-purge of `ChargeMode`) verified
- [ ] Regression check on a laptop where `charge_mode` sysfs *is* writable — kernel source (`asus-armoury.c:755`, `ASUS_ATTR_GROUP_ENUM_INT_RO`) suggests every SKU sees 0444, but confirmation from another maintainer's hardware would be nice
- [ ] Reproduction of the secondary `break → continue` path on hardware where `nv_dynamic_boost` triggers EINVAL

## References

- Closes: #132
- Refs: #144 (prior naive `break → continue` attempt, closed unmerged)
- Refs: b6c85665 (commit that reintroduced the `break` after reverting #144)
- Kernel driver: [`drivers/platform/x86/asus-armoury.c:755`](https://github.com/torvalds/linux/blob/master/drivers/platform/x86/asus-armoury.c#L755) declares `charge_mode` via `ASUS_ATTR_GROUP_ENUM_INT_RO`
- Kernel driver: [`drivers/platform/x86/asus-armoury.h:167`](https://github.com/torvalds/linux/blob/master/drivers/platform/x86/asus-armoury.h#L167) — the macro's expansion sets `.mode = 0444` and omits `.store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)