### PR TITLE
feat(rog-slash): add slash support for GU405 models

### DIFF
--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -19,6 +19,7 @@ pub enum SlashType {
     GU605_2024,
     GU605_2025,
     GU606_2026,
+    GU405_2026,
     G614_2025,
     #[default]
     Unsupported,
@@ -34,6 +35,7 @@ impl SlashType {
             SlashType::GU605_2025 => PROD_ID2,
             SlashType::GU605_2024 => PROD_ID1,
             SlashType::GU606_2026 => PROD_ID2,
+            SlashType::GU405_2026 => PROD_ID2,
             SlashType::G614_2025 => PROD_ID2,
             SlashType::Unsupported => 0,
         }
@@ -48,6 +50,7 @@ impl SlashType {
             SlashType::GU605_2025 => PROD_ID2_STR,
             SlashType::GU605_2024 => PROD_ID1_STR,
             SlashType::GU606_2026 => PROD_ID2_STR,
+            SlashType::GU405_2026 => PROD_ID2_STR,
             SlashType::G614_2025 => PROD_ID2_STR,
             SlashType::Unsupported => "",
         }
@@ -76,6 +79,8 @@ impl SlashType {
             SlashType::GU605_2025
         } else if board_name.contains("GU605") {
             SlashType::GU605_2024
+        } else if board_name.contains("GU405") {
+            SlashType::GU405_2026
         } else {
             SlashType::Unsupported
         }
@@ -94,6 +99,7 @@ impl FromStr for SlashType {
             "GU605_2025" => Self::GU605_2025,
             "GU605_2024" => Self::GU605_2024,
             "GU606_2026" => Self::GU606_2026,
+            "GU405_2026" => Self::GU405_2026,
             "G614_2025" => Self::G614_2025,
             _ => Self::Unsupported,
         })

--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -16,10 +16,10 @@ pub enum SlashType {
     GA403_2025,
     GA605_2024,
     GA605_2025,
+    GU405_2026,
     GU605_2024,
     GU605_2025,
     GU606_2026,
-    GU405_2026,
     G614_2025,
     #[default]
     Unsupported,
@@ -32,10 +32,10 @@ impl SlashType {
             SlashType::GA403_2024 => PROD_ID1,
             SlashType::GA605_2025 => PROD_ID2,
             SlashType::GA605_2024 => PROD_ID2,
+            SlashType::GU405_2026 => PROD_ID2,
             SlashType::GU605_2025 => PROD_ID2,
             SlashType::GU605_2024 => PROD_ID1,
             SlashType::GU606_2026 => PROD_ID2,
-            SlashType::GU405_2026 => PROD_ID2,
             SlashType::G614_2025 => PROD_ID2,
             SlashType::Unsupported => 0,
         }
@@ -47,10 +47,10 @@ impl SlashType {
             SlashType::GA403_2024 => PROD_ID1_STR,
             SlashType::GA605_2025 => PROD_ID2_STR,
             SlashType::GA605_2024 => PROD_ID2_STR,
+            SlashType::GU405_2026 => PROD_ID2_STR,
             SlashType::GU605_2025 => PROD_ID2_STR,
             SlashType::GU605_2024 => PROD_ID1_STR,
             SlashType::GU606_2026 => PROD_ID2_STR,
-            SlashType::GU405_2026 => PROD_ID2_STR,
             SlashType::G614_2025 => PROD_ID2_STR,
             SlashType::Unsupported => "",
         }
@@ -73,14 +73,14 @@ impl SlashType {
             SlashType::GA605_2025
         } else if board_name.contains("GA605") {
             SlashType::GA605_2024
+        } else if board_name.contains("GU405") {
+            SlashType::GU405_2026
         } else if board_name.contains("GU606") {
             SlashType::GU606_2026
         } else if board_name.contains("GU605C") {
             SlashType::GU605_2025
         } else if board_name.contains("GU605") {
             SlashType::GU605_2024
-        } else if board_name.contains("GU405") {
-            SlashType::GU405_2026
         } else {
             SlashType::Unsupported
         }
@@ -96,10 +96,10 @@ impl FromStr for SlashType {
             "GA403_2024" => Self::GA403_2024,
             "GA605_2025" => Self::GA605_2025,
             "GA605_2024" => Self::GA605_2024,
+            "GU405_2026" => Self::GU405_2026,
             "GU605_2025" => Self::GU605_2025,
             "GU605_2024" => Self::GU605_2024,
             "GU606_2026" => Self::GU606_2026,
-            "GU405_2026" => Self::GU405_2026,
             "G614_2025" => Self::G614_2025,
             _ => Self::Unsupported,
         })

--- a/rog-slash/src/usb.rs
+++ b/rog-slash/src/usb.rs
@@ -32,6 +32,7 @@ pub const fn report_id(slash_type: SlashType) -> u8 {
         SlashType::GU605_2025 => REPORT_ID_19B6,
         SlashType::GU605_2024 => REPORT_ID_193B,
         SlashType::GU606_2026 => REPORT_ID_19B6,
+        SlashType::GU405_2026 => REPORT_ID_19B6,
         SlashType::G614_2025 => REPORT_ID_19B6,
         SlashType::Unsupported => REPORT_ID_19B6,
     }

--- a/rog-slash/src/usb.rs
+++ b/rog-slash/src/usb.rs
@@ -29,10 +29,10 @@ pub const fn report_id(slash_type: SlashType) -> u8 {
         SlashType::GA403_2024 => REPORT_ID_193B,
         SlashType::GA605_2025 => REPORT_ID_19B6,
         SlashType::GA605_2024 => REPORT_ID_19B6,
+        SlashType::GU405_2026 => REPORT_ID_19B6,
         SlashType::GU605_2025 => REPORT_ID_19B6,
         SlashType::GU605_2024 => REPORT_ID_193B,
         SlashType::GU606_2026 => REPORT_ID_19B6,
-        SlashType::GU405_2026 => REPORT_ID_19B6,
         SlashType::G614_2025 => REPORT_ID_19B6,
         SlashType::Unsupported => REPORT_ID_19B6,
     }


### PR DESCRIPTION
# Description

Slash support for the ROG Zephyrus G14 **GU405AR**. Board name `GU405AR`, device `0b05:19b6`.

```
[INFO  asusd::aura_types]   Unknown or invalid slash: "19b6", skipping
[INFO  asusd::aura_manager] Tested device was not Slash
```

This adds a `GU405_2026` variant mapped to `PROD_ID2` / `REPORT_ID_19B6` plus a `GU405` board-name match  (I followed #281 for the GU606AX as an example).

Like the GU606AX, this laptop exposes a single HID interface, the slash shares it with the keyboard.

After the patch:

```
[INFO  asusd::aura_types] Found slash type GU405_2026: 19b6
```

```
$ busctl --system introspect xyz.ljones.Asusd /xyz/ljones/aura/19b6_2_5 xyz.ljones.Slash
NAME                TYPE     SIGNATURE RESULT/VALUE FLAGS
.DeviceState        method   -         (byyu)       -
.Brightness         property y         255          emits-change writable
.Enabled            property b         true         emits-change writable
.Interval           property y         0            emits-change writable
.Mode               property y         0            emits-change writable
.ShowOnBoot         property b         true         emits-change writable
...
```

Enable, brightness, and mode changes all working.

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Zephyrus G14 GU405AR
- **Linux Distribution:** Arch
- **Kernel Version:** 7.1.8-arch1-3

# Verification and testing:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
