### PR TITLE
feat: add human panic basic functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ env_logger = "^0.11.11"
 futures-util = "^0.3.33"
 gif = "^0.14.2"
 glam = { version = "^0.33.2", features = ["serde"] }
+human-panic = "^2.0.8"
 image = "^0.25.10"
 inotify = "^0.11.4"
 ksni = { version = "^0.3.6", default-features = false, features = ["async-io"] }

--- a/asus-shutdown/Cargo.toml
+++ b/asus-shutdown/Cargo.toml
@@ -20,3 +20,4 @@ futures-util.workspace = true
 
 log.workspace = true
 env_logger.workspace = true
+human-panic.workspace = true

--- a/asus-shutdown/src/main.rs
+++ b/asus-shutdown/src/main.rs
@@ -58,6 +58,14 @@ struct DiscreteGpu {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    human_panic::setup_panic!(human_panic::Metadata::new(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    )
+    .authors(env!("CARGO_PKG_AUTHORS"))
+    .homepage(env!("CARGO_PKG_HOMEPAGE"))
+    .support("Open an issue at https://github.com/OpenGamingCollective/asusctl/issues and attach the crash report."));
+
     let mut logger = env_logger::Builder::new();
     logger
         .parse_default_env()

--- a/asusctl/Cargo.toml
+++ b/asusctl/Cargo.toml
@@ -24,6 +24,7 @@ env_logger.workspace = true
 ron.workspace = true
 zbus.workspace = true
 argh.workspace = true
+human-panic.workspace = true
 
 [dev-dependencies]
 rog_dbus = { path = "../rog-dbus" }

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -43,6 +43,14 @@ mod slash_cli;
 mod xgm_led_cli;
 
 fn main() {
+    human_panic::setup_panic!(human_panic::Metadata::new(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    )
+    .authors(env!("CARGO_PKG_AUTHORS"))
+    .homepage(env!("CARGO_PKG_HOMEPAGE"))
+    .support("Open an issue at https://github.com/OpenGamingCollective/asusctl/issues and attach the crash report."));
+
     // Ensure tracing spans are quiet by default unless user overrides
     if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "warn,tracing=error,zbus=error");

--- a/asusd-user/Cargo.toml
+++ b/asusd-user/Cargo.toml
@@ -33,6 +33,7 @@ config-traits = { path = "../config-traits" }
 zbus.workspace = true
 log.workspace = true
 env_logger.workspace = true
+human-panic.workspace = true
 thiserror.workspace = true
 
 [package.metadata.deb]

--- a/asusd-user/src/daemon.rs
+++ b/asusd-user/src/daemon.rs
@@ -23,6 +23,14 @@ const BOARD_NAME: &str = "/sys/class/dmi/id/board_name";
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    human_panic::setup_panic!(human_panic::Metadata::new(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    )
+    .authors(env!("CARGO_PKG_AUTHORS"))
+    .homepage(env!("CARGO_PKG_HOMEPAGE"))
+    .support("Open an issue at https://github.com/OpenGamingCollective/asusctl/issues and attach the crash report."));
+
     let mut logger = env_logger::Builder::new();
     logger
         .filter_level(log::LevelFilter::Info)

--- a/asusd/Cargo.toml
+++ b/asusd/Cargo.toml
@@ -32,6 +32,7 @@ tokio.workspace = true
 # cli and logging
 log.workspace = true
 env_logger.workspace = true
+human-panic.workspace = true
 
 futures-util.workspace = true
 zbus.workspace = true

--- a/asusd/src/daemon.rs
+++ b/asusd/src/daemon.rs
@@ -21,6 +21,14 @@ use zbus::fdo::ObjectManager;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    human_panic::setup_panic!(human_panic::Metadata::new(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    )
+    .authors(env!("CARGO_PKG_AUTHORS"))
+    .homepage(env!("CARGO_PKG_HOMEPAGE"))
+    .support("Open an issue at https://github.com/OpenGamingCollective/asusctl/issues and attach the crash report."));
+
     println!("Starting asusd daemon...");
 
     // console_subscriber::init();

--- a/rog-control-center/Cargo.toml
+++ b/rog-control-center/Cargo.toml
@@ -33,6 +33,7 @@ rog_slash = { path = "../rog-slash" }
 dmi_id = { path = "../dmi-id" }
 
 argh.workspace = true
+human-panic.workspace = true
 log.workspace = true
 env_logger.workspace = true
 

--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -24,6 +24,14 @@ use tokio::runtime::Runtime;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    human_panic::setup_panic!(human_panic::Metadata::new(
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    )
+    .authors(env!("CARGO_PKG_AUTHORS"))
+    .homepage(env!("CARGO_PKG_HOMEPAGE"))
+    .support("Open an issue at https://github.com/OpenGamingCollective/asusctl/issues and attach the crash report."));
+
     // Ensure tracing spans are quiet by default unless user overrides
     if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "warn,tracing=error,zbus=error");


### PR DESCRIPTION
# Description

Until now, issues were made poorly using AI or a bit of brain: We can't simply accept it anymore as it can lead to misleading info in the long run and also create fix for bugs not really present. That's why I propose to use human-panic as basic help to create a real issue instead of hope to be able to reproduce an AI made issue.

As for now I leave it alone as a draft: if you have further requirements/suggestions feel free to do so

Fixes: N/A

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
