### PR TITLE
fix(rog-control-center): adapt XDG global shortcuts to new KDE portal lifecycle and clean up session management

### DIFF
--- a/rog-control-center/src/shortcuts.rs
+++ b/rog-control-center/src/shortcuts.rs
@@ -299,6 +299,30 @@ async fn bind_shortcut(
     }
 }
 
+async fn configure_shortcuts(
+    gs: &GlobalShortcuts,
+    session: &ashpd::desktop::Session<GlobalShortcuts>,
+) -> bool {
+    if gs.version() >= 2 {
+        match gs
+            .configure_shortcuts(session, None, ConfigureShortcutsOptions::default())
+            .await
+        {
+            Ok(()) => true,
+            Err(err) => {
+                warn!("ConfigureShortcuts failed: {err}");
+                false
+            }
+        }
+    } else {
+        warn!(
+            "ConfigureShortcuts needs portal version 2 (have {})",
+            gs.version()
+        );
+        false
+    }
+}
+
 async fn apply_enable(
     gs: &GlobalShortcuts,
     session: &ashpd::desktop::Session<GlobalShortcuts>,
@@ -311,14 +335,9 @@ async fn apply_enable(
         *current = bind_shortcut(gs, session).await?;
     }
 
-    if *current != Assignment::Assigned && mode == EnableMode::Interactive && gs.version() >= 2 {
+    if *current != Assignment::Assigned && mode == EnableMode::Interactive {
         // KDE requires configure for an existing empty trigger.
-        if let Err(err) = gs
-            .configure_shortcuts(session, None, ConfigureShortcutsOptions::default())
-            .await
-        {
-            warn!("Could not open shortcut configuration: {err}");
-        }
+        configure_shortcuts(gs, session).await;
     }
 
     Ok(match current {
@@ -429,13 +448,7 @@ async fn run_session_inner(
         }
     };
 
-    let mut current = match query_assignment(gs, session).await {
-        Ok(found) => found,
-        Err(err) => {
-            error!("Could not list shortcuts: {err}");
-            return ShortcutStatus::Unavailable;
-        }
-    };
+    let mut current = Assignment::Missing;
     let mut bind_attempted = false;
 
     let mut current_status =
@@ -458,24 +471,7 @@ async fn run_session_inner(
                 match command {
                     Some(Command::Disable) => break ShortcutStatus::Disabled,
                     Some(Command::Configure { respond }) => {
-                        let ok = if gs.version() >= 2 {
-                            match gs
-                                .configure_shortcuts(session, None, ConfigureShortcutsOptions::default())
-                                .await
-                            {
-                                Ok(()) => true,
-                                Err(err) => {
-                                    warn!("ConfigureShortcuts failed: {err}");
-                                    false
-                                }
-                            }
-                        } else {
-                            warn!(
-                                "ConfigureShortcuts needs portal version 2 (have {})",
-                                gs.version()
-                            );
-                            false
-                        };
+                        let ok = configure_shortcuts(gs, session).await;
                         let _ = respond.send(ok);
                     }
                     Some(Command::Enable { mode, respond }) => {

--- a/rog-control-center/src/shortcuts.rs
+++ b/rog-control-center/src/shortcuts.rs
@@ -306,25 +306,21 @@ async fn apply_enable(
     bind_attempted: &mut bool,
     mode: EnableMode,
 ) -> ashpd::Result<ShortcutStatus> {
-    if *current != Assignment::Assigned && mode == EnableMode::Interactive {
-        match *current {
-            Assignment::Missing if !*bind_attempted => {
-                // A failed or cancelled bind may still persist state.
-                *bind_attempted = true;
-                *current = bind_shortcut(gs, session).await?;
-            }
-            Assignment::Unassigned if gs.version() >= 2 => {
-                // KDE requires Configure for an existing empty trigger.
-                if let Err(err) = gs
-                    .configure_shortcuts(session, None, ConfigureShortcutsOptions::default())
-                    .await
-                {
-                    warn!("Could not open shortcut configuration: {err}");
-                }
-            }
-            _ => {}
+    if !*bind_attempted {
+        *bind_attempted = true;
+        *current = bind_shortcut(gs, session).await?;
+    }
+
+    if *current != Assignment::Assigned && mode == EnableMode::Interactive && gs.version() >= 2 {
+        // KDE requires configure for an existing empty trigger.
+        if let Err(err) = gs
+            .configure_shortcuts(session, None, ConfigureShortcutsOptions::default())
+            .await
+        {
+            warn!("Could not open shortcut configuration: {err}");
         }
     }
+
     Ok(match current {
         Assignment::Assigned => ShortcutStatus::Listening,
         _ => ShortcutStatus::Unassigned,

--- a/rog-control-center/src/ui/mod.rs
+++ b/rog-control-center/src/ui/mod.rs
@@ -293,7 +293,6 @@ pub fn setup_app_settings_page(
 
         let toggle_handle = handle.clone();
         let config_copy = config.clone();
-        let weak = ui.as_weak();
         global.on_set_enable_global_shortcut(move |enable| {
             if enable {
                 match config_copy.lock() {
@@ -304,31 +303,8 @@ pub fn setup_app_settings_page(
                     Err(err) => error!("Could not save global shortcut setting: {err}"),
                 }
                 let handle = toggle_handle.clone();
-                let config = config_copy.clone();
-                let weak = weak.clone();
                 tokio::spawn(async move {
-                    let status = handle.enable(EnableMode::Interactive).await;
-                    if status == ShortcutStatus::Unassigned {
-                        // The user cancelled the first-time bind dialog, so
-                        // the feature can do nothing: revert the intent.
-                        match config.lock() {
-                            Ok(mut lock) => {
-                                lock.enable_global_shortcut = false;
-                                lock.write();
-                            }
-                            Err(err) => {
-                                error!("Could not revert global shortcut setting: {err}")
-                            }
-                        }
-                        handle.disable().await;
-                        weak.upgrade_in_event_loop(|ui| {
-                            ui.global::<AppSettingsPageData>()
-                                .set_enable_global_shortcut(false);
-                        })
-                        .ok();
-                    }
-                    // `Unavailable` keeps the config: the failure may be
-                    // temporary and the next startup will retry the restore.
+                    handle.enable(EnableMode::Interactive).await;
                 });
             } else {
                 match config_copy.lock() {

--- a/rog-control-center/src/ui/mod.rs
+++ b/rog-control-center/src/ui/mod.rs
@@ -294,31 +294,21 @@ pub fn setup_app_settings_page(
         let toggle_handle = handle.clone();
         let config_copy = config.clone();
         global.on_set_enable_global_shortcut(move |enable| {
-            if enable {
-                match config_copy.lock() {
-                    Ok(mut lock) => {
-                        lock.enable_global_shortcut = true;
-                        lock.write();
-                    }
-                    Err(err) => error!("Could not save global shortcut setting: {err}"),
+            match config_copy.lock() {
+                Ok(mut lock) => {
+                    lock.enable_global_shortcut = enable;
+                    lock.write();
                 }
-                let handle = toggle_handle.clone();
-                tokio::spawn(async move {
-                    handle.enable(EnableMode::Interactive).await;
-                });
-            } else {
-                match config_copy.lock() {
-                    Ok(mut lock) => {
-                        lock.enable_global_shortcut = false;
-                        lock.write();
-                    }
-                    Err(err) => error!("Could not save global shortcut setting: {err}"),
-                }
-                let handle = toggle_handle.clone();
-                tokio::spawn(async move {
-                    handle.disable().await;
-                });
+                Err(err) => error!("Could not save global shortcut setting: {err}"),
             }
+            let handle = toggle_handle.clone();
+            tokio::spawn(async move {
+                if enable {
+                    handle.enable(EnableMode::Interactive).await;
+                } else {
+                    handle.disable().await;
+                }
+            });
         });
 
         global.on_manage_global_shortcut(move || {


### PR DESCRIPTION
# Description

This PR fixes global shortcuts failing to activate or be configured on KDE Plasma (`xdg-desktop-portal-kde`) following recent upstream changes, and cleans up the portal session lifecycle and UI callbacks.

### Context & Root Cause

In KDE Plasma, commit [2f9ae51e](https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/commit/2f9ae51e29b06b2bf64f7f863a3e0b0b1d28be05) removed automatic shortcut registration from `GlobalShortcutsSession::loadActions()`, requiring that shortcuts only become active when `BindShortcuts` is explicitly invoked on the session.

Previously:
1. `rog-control-center` skipped calling `bind_shortcuts` on startup restore (`EnableMode::Restore`) or whenever shortcuts were already listed by the portal, leaving them unhooked in `KGlobalAccel`.
2. When toggling global shortcuts on in the UI while in `ShortcutStatus::Unassigned`, the callback immediately tore down the D-Bus session and reset the configuration before the user could configure the shortcut in KDE's portal dialog.
3. Redundant D-Bus roundtrips (`ListShortcuts`) were performed on session creation before binding.

### Summary of Changes

- **Fix KDE Plasma lifecycle (`shortcuts.rs`)**: Always invoke `bind_shortcut` upon session creation in `apply_enable`, ensuring shortcuts are properly registered with `KGlobalAccel` across all desktop environments.
- **Refactor session initialization & deduplicate portal config (`shortcuts.rs`)**:
  - Removed redundant `query_assignment` on startup, as `bind_shortcut` already inspects portal assignments.
  - Extracted `configure_shortcuts` helper to centralize portal version checks (`>= 2`) and warning logging.
- **UI callback cleanup (`ui/mod.rs`)**:
  - Prevent premature portal session shutdown when `ShortcutStatus::Unassigned` is returned, keeping the session alive for user configuration.
  - Consolidated `Config` lock acquisition and async command dispatch in `on_set_enable_global_shortcut`.

# Verification and testing

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)