### PR TITLE
fix(asusd): validate hardware writes and add fallback for unapplicable armoury attributes

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -653,26 +653,39 @@ pub async fn set_config_or_default(
                     continue;
                 }
 
-                if let Some(tune) = tuning.group.get(&name) {
-                    attr.set_current_value(&AttrValue::Integer(*tune))
-                        .map_err(|e| {
-                            error!("Failed to set {}: {e}", <&str>::from(name));
-                        })
-                        .ok();
+                let target_val = tuning.group.get(&name).copied();
+                let applied = match target_val {
+                    Some(tune) => attr.set_current_value(&AttrValue::Integer(tune)).is_ok(),
+                    None => false,
+                };
+
+                let final_val = if applied {
+                    target_val
                 } else {
-                    let default = attr.default_value();
-                    attr.set_current_value(default)
-                        .map_err(|e| {
-                            error!("Failed to set {}: {e}", <&str>::from(name));
-                        })
-                        .ok();
-                    if let AttrValue::Integer(i) = default {
-                        tuning.group.insert(name, *i);
-                        info!(
-                            "Set default tuning config for {} = {:?}",
-                            <&str>::from(name),
-                            i
+                    if target_val.is_some() {
+                        warn!(
+                            "Failed to set PPT {}: falling back to default/current value.",
+                            <&str>::from(name)
                         );
+                    }
+                    let default = attr.default_value();
+                    if attr.set_current_value(default).is_ok() {
+                        match default {
+                            AttrValue::Integer(i) => Some(*i),
+                            _ => None,
+                        }
+                    } else {
+                        match attr.current_value() {
+                            Ok(AttrValue::Integer(cur)) => Some(cur),
+                            _ => None,
+                        }
+                    }
+                };
+
+                if let Some(val) = final_val {
+                    if target_val != Some(val) {
+                        tuning.group.insert(name, val);
+                        info!("Set tuning config for {} = {:?}", <&str>::from(name), val);
                         changed = true;
                     }
                 }

--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -247,13 +247,19 @@ impl crate::Reloadable for AsusArmouryAttribute {
             }
             _ => {
                 info!("Applying value {apply_value:?} to attribute {name}");
-                self.attr.set_current_value(&apply_value).map_err(|e| {
-                    error!("Could not set {name} value: {e:?}");
-                    self.attr.base_path_exists();
-                    e
-                })?;
-
-                info!("Restored asus-armoury setting {name} to {apply_value:?}");
+                if let Err(e) = self.attr.set_current_value(&apply_value) {
+                    if attribute.property_type() == FirmwareAttributeType::Ppt {
+                        warn!(
+                            "Could not restore PPT setting {name} to {apply_value:?}: {e:?}. Hardware may restrict this setting in current power state."
+                        );
+                    } else {
+                        error!("Could not set {name} value: {e:?}");
+                        self.attr.base_path_exists();
+                        return Err(e.into());
+                    }
+                } else {
+                    info!("Restored asus-armoury setting {name} to {apply_value:?}");
+                }
             }
         }
 
@@ -317,36 +323,47 @@ impl AsusArmouryAttribute {
     }
 
     async fn restore_default(&self) -> fdo::Result<()> {
-        self.attr.restore_default()?;
-        if self.name().property_type() == FirmwareAttributeType::Ppt {
-            let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
-            let power_plugged = self
-                .power
-                .get_online()
-                .map_err(|e| {
-                    error!("Could not get power status: {e:?}");
-                    e
-                })
-                .unwrap_or_default();
+        let name = self.attr.name();
+        match self.name().property_type() {
+            FirmwareAttributeType::ReadOnly => {
+                warn!("Attempted to restore read-only attribute {name}: write discarded");
+                Err(fdo::Error::NotSupported(format!(
+                    "{name} is read-only and cannot be changed"
+                )))
+            }
+            FirmwareAttributeType::Ppt => {
+                let AttrValue::Integer(default_val) = *self.attr.default_value() else {
+                    return Err(fdo::Error::NotSupported(format!(
+                        "No default value available for {name}"
+                    )));
+                };
 
-            let mut config = self.config.lock().await;
-            let tuning = config.select_tunings(power_plugged == 1, profile);
-            if let Some(tune) = tuning.group.get_mut(&self.name()) {
-                if let AttrValue::Integer(i) = self.attr.default_value() {
-                    *tune = *i;
+                let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
+                let power_plugged = self.power.get_online().unwrap_or_default() == 1;
+
+                let mut config = self.config.lock().await;
+                let tuning = config.select_tunings(power_plugged, profile);
+                if tuning.enabled {
+                    self.attr
+                        .set_current_value(&AttrValue::Integer(default_val))
+                        .map_err(|e| {
+                            error!("Could not set value: {e:?}");
+                            e
+                        })?;
                 }
+                tuning.group.insert(self.name(), default_val);
+                config.write();
+                Ok(())
             }
-            if tuning.enabled {
-                self.attr
-                    .set_current_value(self.attr.default_value())
-                    .map_err(|e| {
-                        error!("Could not set value: {e:?}");
-                        e
-                    })?;
+            _ => {
+                self.attr.restore_default()?;
+                let mut config = self.config.lock().await;
+                if config.armoury_settings.remove(&self.name()).is_some() {
+                    config.write();
+                }
+                Ok(())
             }
-            config.write();
         }
-        Ok(())
     }
 
     #[zbus(property)]
@@ -379,20 +396,17 @@ impl AsusArmouryAttribute {
     async fn current_value(&self) -> fdo::Result<i32> {
         if self.name().property_type() == FirmwareAttributeType::Ppt {
             let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
-            let power_plugged = self
-                .power
-                .get_online()
-                .map_err(|e| {
-                    error!("Could not get power status: {e:?}");
-                    e
-                })
-                .unwrap_or_default()
-                == 1;
+            let power_plugged = self.power.get_online().unwrap_or_default() == 1;
             let config = self.config.lock().await;
             if let Some(tuning) = config.select_tunings_ref(power_plugged, profile) {
-                if let Some(tune) = tuning.group.get(&self.name()) {
-                    return Ok(*tune);
+                if tuning.enabled {
+                    if let Some(tune) = tuning.group.get(&self.name()) {
+                        return Ok(*tune);
+                    }
                 }
+            }
+            if let Ok(AttrValue::Integer(cur)) = self.attr.current_value() {
+                return Ok(cur);
             }
             if let AttrValue::Integer(i) = self.attr.default_value() {
                 return Ok(*i);
@@ -436,38 +450,28 @@ impl AsusArmouryAttribute {
             )));
         }
 
-        let apply_value = match self.name().property_type() {
+        let (apply_value, ppt_context) = match self.name().property_type() {
             FirmwareAttributeType::Ppt => {
                 let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
-                let power_plugged = self
-                    .power
-                    .get_online()
-                    .map_err(|e| {
-                        error!("Could not get power status: {e:?}");
-                        e
-                    })
-                    .unwrap_or_default();
+                let power_plugged = self.power.get_online().unwrap_or_default() == 1;
 
-                let mut config = self.config.lock().await;
-                let tuning = config.select_tunings(power_plugged == 1, profile);
+                let config = self.config.lock().await;
+                let tuning_enabled = config
+                    .select_tunings_ref(power_plugged, profile)
+                    .map(|t| t.enabled)
+                    .unwrap_or(false);
 
-                if let Some(tune) = tuning.group.get_mut(&self.name()) {
-                    *tune = value;
-                } else {
-                    tuning.group.insert(self.name(), value);
-                    debug!("Store tuning config for {name} = {:?}", value);
+                if !tuning_enabled {
+                    warn!(
+                        "Cannot set PPT property {name}: profile tuning is disabled for current profile and power state"
+                    );
+                    return Err(fdo::Error::Failed(format!(
+                        "Cannot set PPT property {name}: profile tuning is disabled for current profile and power state. Enable tuning first."
+                    )));
                 }
 
-                match tuning.enabled {
-                    true => {
-                        debug!("Tuning is enabled: setting value to PPT property {name} = {value}");
-                        AttrValue::Integer(value)
-                    }
-                    false => {
-                        warn!("Tuning is disabled: skipping setting value to PPT property {name}");
-                        AttrValue::None
-                    }
-                }
+                debug!("Tuning is enabled: setting value to PPT property {name} = {value}");
+                (AttrValue::Integer(value), Some((profile, power_plugged)))
             }
             FirmwareAttributeType::Gpu => {
                 debug!("Queueing GPU attribute {name} = {value} for delayed apply");
@@ -484,36 +488,29 @@ impl AsusArmouryAttribute {
                     })?;
                 return Ok(());
             }
-            _ => {
-                let mut settings = self.config.lock().await;
-                settings
-                    .armoury_settings
-                    .entry(self.name())
-                    .and_modify(|setting| {
-                        debug!("Set config for {name} = {value}");
-                        *setting = value;
-                    })
-                    .or_insert_with(|| {
-                        debug!("Adding config for {name} = {value}");
-                        value
-                    });
-
-                AttrValue::Integer(value)
-            }
+            _ => (AttrValue::Integer(value), None),
         };
 
-        // Only write to sysfs if we have a real value to apply.
-        // When tuning is disabled, the value is stored in config but not
-        // written to hardware — it will be applied when tuning is enabled.
-        if !matches!(apply_value, AttrValue::None) {
-            self.attr.set_current_value(&apply_value).map_err(|e| {
-                error!("Could not set value {value} to attribute {name}: {e:?}");
-                e
-            })?;
-        }
+        // Write to sysfs first. If kernel rejects the value (e.g. invalid on battery),
+        // we return Err immediately and DO NOT modify in-memory or persisted config.
+        self.attr.set_current_value(&apply_value).map_err(|e| {
+            error!("Could not set value {value} to attribute {name}: {e:?}");
+            e
+        })?;
 
-        // write config after setting value
-        self.config.lock().await.write();
+        // Commit to in-memory config and persist to disk ONLY AFTER successful hardware write.
+        {
+            let mut config = self.config.lock().await;
+            if let Some((profile, power_plugged)) = ppt_context {
+                let tuning = config.select_tunings(power_plugged, profile);
+                tuning.group.insert(self.name(), value);
+                debug!("Store tuning config for {name} = {:?}", value);
+            } else {
+                config.armoury_settings.insert(self.name(), value);
+                debug!("Set config for {name} = {value}");
+            }
+            config.write();
+        }
 
         // When an nv_* attribute (Nvidia TDP/temp) is written, restart
         // nvidia-powerd so it re-reads the new TDP limits from hardware.
@@ -540,14 +537,8 @@ impl AsusArmouryAttribute {
         if self.name().property_type() != FirmwareAttributeType::Gpu {
             return Ok(-1);
         }
-
-        Ok(self
-            .queued_gpu
-            .lock()
-            .await
-            .get(&self.name())
-            .copied()
-            .unwrap_or(-1))
+        let queued = self.queued_gpu.lock().await;
+        Ok(queued.get(&self.name()).copied().unwrap_or(-1))
     }
 
     /// Applies queued GPU value if present and returns whether anything was applied.
@@ -613,6 +604,8 @@ pub async fn start_attributes_zbus(
                 "Skipping attribute '{}' due to reload error: {e:?}",
                 attr.attr.name()
             );
+            // Stop registering remaining attributes on reload failure to prevent
+            // exposing partially initialized or inconsistent hardware state.
             break;
         }
 

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use config_traits::StdConfig;
 use log::{debug, error, info, warn};
-use rog_platform::asus_armoury::{
-    AttrValue, FirmwareAttribute, FirmwareAttributeType, FirmwareAttributes,
-};
+use rog_platform::asus_armoury::FirmwareAttributes;
 use rog_platform::cpu::{CPUControl, CPUEPP, CPUGovernor};
 use rog_platform::platform::{PlatformProfile, Properties, RogPlatform};
 use rog_platform::power::AsusPower;
@@ -761,39 +759,13 @@ impl CtrlPlatform {
         }
 
         if enable {
-            // Clone to reduce blocking
-            let tuning = self
-                .config
-                .lock()
-                .await
-                .select_tunings(power_plugged == 1, profile)
-                .clone();
-
-            for attr in self.attributes.attributes() {
-                let name: FirmwareAttribute = attr.name().into();
-                if name.property_type() == FirmwareAttributeType::Ppt {
-                    // reset stored value
-                    if let Some(tune) = self
-                        .config
-                        .lock()
-                        .await
-                        .select_tunings(power_plugged == 1, profile)
-                        .group
-                        .get_mut(&name)
-                    {
-                        let value = tuning
-                            .group
-                            .get(&name)
-                            .map(|v| AttrValue::Integer(*v))
-                            .unwrap_or_else(|| attr.default_value().clone());
-                        // restore default
-                        attr.set_current_value(&value)?;
-                        if let AttrValue::Integer(i) = value {
-                            *tune = i
-                        }
-                    }
-                }
-            }
+            set_config_or_default(
+                &self.attributes,
+                &mut *self.config.lock().await,
+                power_plugged == 1,
+                profile,
+            )
+            .await;
         } else {
             // reapply the profile to ensure acpi resets PPT to defaults
             self.platform.set_platform_profile(profile.into())?;


### PR DESCRIPTION
## Description

This PR fixes the root cause of #132 where `asusd` failed on battery startup due to unapplicable PPT tuning values being persisted and re-applied to sysfs.

ASUS WMI firmware attributes often advertise static AC defaults (e.g. `nv_dynamic_boost: 20`) that return `EINVAL` when written while running on battery. Previously, `asusd` updated its in-memory configuration and serialized to `/etc/asusd/asusd.ron` *before* verifying the hardware write, causing rejected values to contaminate disk configuration and fail subsequent daemon reloads on boot.

---

### Key Changes:

- **`asusd` (Armoury Controller & Configuration Integrity)**:
  - **Validate before persist (`set_current_value`)**: Hardware writes to sysfs are executed **before** updating `Arc<Mutex<Config>>` and persisting to `/etc/asusd/asusd.ron`. If the kernel/firmware rejects the write (e.g., `EINVAL` on battery or out-of-range value), the function returns an error immediately and leaves in-memory state and disk configuration uncontaminated.
  - **Tuning toggle guard**: Property modifications via D-Bus are rejected if PPT profile tuning is disabled for the active profile and power state.
  - **Dynamic fallback chain (`set_config_or_default`)**: When applying profile tuning or generating defaults on startup, if a static driver default (e.g., `nv_dynamic_boost = 20`) is rejected by firmware in the current power state, `asusd` gracefully falls back to querying the active hardware value (`attr.current_value()`).
  - **Resilient daemon startup (`reload`)**: Differentiates power-state write restrictions during `reload` (logged as non-fatal warnings) from unrecoverable attribute errors, preserving the fail-fast `break;` policy without false-positive boot crashes.
- **`asusd` (Platform Controller)**:
  - **Deduplicate PPT enablement (`set_enable_ppt_group`)**: Replaced the manual attribute loop with delegation to `set_config_or_default`, ensuring consistent fallback, locking, and persistence behavior across runtime profile activations.

Fixes #132

---

## Verification and Testing

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky passes with 0 warnings (`cargo cranky`)
