### PR TITLE
refactor(asusd): simplify armoury attribute persistence and restore logic [2/2]

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -247,13 +247,19 @@ impl crate::Reloadable for AsusArmouryAttribute {
             }
             _ => {
                 info!("Applying value {apply_value:?} to attribute {name}");
-                self.attr.set_current_value(&apply_value).map_err(|e| {
-                    error!("Could not set {name} value: {e:?}");
-                    self.attr.base_path_exists();
-                    e
-                })?;
-
-                info!("Restored asus-armoury setting {name} to {apply_value:?}");
+                if let Err(e) = self.attr.set_current_value(&apply_value) {
+                    if attribute.property_type() == FirmwareAttributeType::Ppt {
+                        warn!(
+                            "Could not restore PPT setting {name} to {apply_value:?}: {e:?}. Hardware may restrict this setting in current power state."
+                        );
+                    } else {
+                        error!("Could not set {name} value: {e:?}");
+                        self.attr.base_path_exists();
+                        return Err(e.into());
+                    }
+                } else {
+                    info!("Restored asus-armoury setting {name} to {apply_value:?}");
+                }
             }
         }
 
@@ -394,6 +400,9 @@ impl AsusArmouryAttribute {
                     return Ok(*tune);
                 }
             }
+            if let Ok(AttrValue::Integer(cur)) = self.attr.current_value() {
+                return Ok(cur);
+            }
             if let AttrValue::Integer(i) = self.attr.default_value() {
                 return Ok(*i);
             }
@@ -448,25 +457,18 @@ impl AsusArmouryAttribute {
                     })
                     .unwrap_or_default();
 
-                let mut config = self.config.lock().await;
-                let tuning = config.select_tunings(power_plugged == 1, profile);
+                let config = self.config.lock().await;
+                let tuning_enabled = config
+                    .select_tunings_ref(power_plugged == 1, profile)
+                    .map(|t| t.enabled)
+                    .unwrap_or(false);
 
-                if let Some(tune) = tuning.group.get_mut(&self.name()) {
-                    *tune = value;
+                if tuning_enabled {
+                    debug!("Tuning is enabled: setting value to PPT property {name} = {value}");
+                    AttrValue::Integer(value)
                 } else {
-                    tuning.group.insert(self.name(), value);
-                    debug!("Store tuning config for {name} = {:?}", value);
-                }
-
-                match tuning.enabled {
-                    true => {
-                        debug!("Tuning is enabled: setting value to PPT property {name} = {value}");
-                        AttrValue::Integer(value)
-                    }
-                    false => {
-                        warn!("Tuning is disabled: skipping setting value to PPT property {name}");
-                        AttrValue::None
-                    }
+                    warn!("Tuning is disabled: skipping setting value to PPT property {name}");
+                    AttrValue::None
                 }
             }
             FirmwareAttributeType::Gpu => {
@@ -484,22 +486,7 @@ impl AsusArmouryAttribute {
                     })?;
                 return Ok(());
             }
-            _ => {
-                let mut settings = self.config.lock().await;
-                settings
-                    .armoury_settings
-                    .entry(self.name())
-                    .and_modify(|setting| {
-                        debug!("Set config for {name} = {value}");
-                        *setting = value;
-                    })
-                    .or_insert_with(|| {
-                        debug!("Adding config for {name} = {value}");
-                        value
-                    });
-
-                AttrValue::Integer(value)
-            }
+            _ => AttrValue::Integer(value),
         };
 
         // Only write to sysfs if we have a real value to apply.
@@ -512,8 +499,46 @@ impl AsusArmouryAttribute {
             })?;
         }
 
-        // write config after setting value
-        self.config.lock().await.write();
+        // Commit to in-memory config and persist to disk ONLY AFTER successful hardware write
+        // (or when tuning is disabled and hardware write was intentionally skipped).
+        {
+            let mut config = self.config.lock().await;
+            match self.name().property_type() {
+                FirmwareAttributeType::Ppt => {
+                    let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
+                    let power_plugged = self
+                        .power
+                        .get_online()
+                        .map_err(|e| {
+                            error!("Could not get power status: {e:?}");
+                            e
+                        })
+                        .unwrap_or_default();
+
+                    let tuning = config.select_tunings(power_plugged == 1, profile);
+                    if let Some(tune) = tuning.group.get_mut(&self.name()) {
+                        *tune = value;
+                    } else {
+                        tuning.group.insert(self.name(), value);
+                        debug!("Store tuning config for {name} = {:?}", value);
+                    }
+                }
+                _ => {
+                    config
+                        .armoury_settings
+                        .entry(self.name())
+                        .and_modify(|setting| {
+                            debug!("Set config for {name} = {value}");
+                            *setting = value;
+                        })
+                        .or_insert_with(|| {
+                            debug!("Adding config for {name} = {value}");
+                            value
+                        });
+                }
+            }
+            config.write();
+        }
 
         // When an nv_* attribute (Nvidia TDP/temp) is written, restart
         // nvidia-powerd so it re-reads the new TDP limits from hardware.
@@ -668,17 +693,30 @@ pub async fn set_config_or_default(
                         .ok();
                 } else {
                     let default = attr.default_value();
-                    attr.set_current_value(default)
-                        .map_err(|e| {
-                            error!("Failed to set {}: {e}", <&str>::from(name));
-                        })
-                        .ok();
-                    if let AttrValue::Integer(i) = default {
-                        tuning.group.insert(name, *i);
+                    let value_to_save = match attr.set_current_value(default) {
+                        Ok(()) => match default {
+                            AttrValue::Integer(i) => Some(*i),
+                            _ => None,
+                        },
+                        Err(e) => {
+                            warn!(
+                                "Default value {:?} for {} rejected on current power state: {e}. Falling back to active current_value.",
+                                default,
+                                <&str>::from(name)
+                            );
+                            match attr.current_value() {
+                                Ok(AttrValue::Integer(cur)) => Some(cur),
+                                _ => None,
+                            }
+                        }
+                    };
+
+                    if let Some(val) = value_to_save {
+                        tuning.group.insert(name, val);
                         info!(
                             "Set default tuning config for {} = {:?}",
                             <&str>::from(name),
-                            i
+                            val
                         );
                         changed = true;
                     }

--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -181,7 +181,8 @@ impl crate::Reloadable for AsusArmouryAttribute {
         let name = self.attr.name();
 
         let mut config = self.config.lock().await;
-        let apply_value = match attribute.property_type() {
+        let prop_type = attribute.property_type();
+        let apply_value = match prop_type {
             FirmwareAttributeType::Ppt => {
                 let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
                 let power_plugged = self
@@ -205,28 +206,12 @@ impl crate::Reloadable for AsusArmouryAttribute {
 
                 apply_value.map_or(AttrValue::None, AttrValue::Integer)
             }
-            FirmwareAttributeType::Gpu => {
+            _ if !prop_type.should_persist_armoury_setting() => {
                 if config.armoury_settings.remove(&attribute).is_some() {
-                    info!("Removed persisted GPU attribute {name} from config");
+                    info!("Removed stale persisted {prop_type:?} attribute {name} from config");
                     config.write();
                 }
-                info!("Reload called on GPU attribute {name}: doing nothing");
-                AttrValue::None
-            }
-            FirmwareAttributeType::ReadOnly => {
-                if config.armoury_settings.remove(&attribute).is_some() {
-                    info!("Removed stale persisted read-only attribute {name} from config");
-                    config.write();
-                }
-                info!("Reload called on read-only attribute {name}: doing nothing");
-                AttrValue::None
-            }
-            FirmwareAttributeType::Norestore => {
-                if config.armoury_settings.remove(&attribute).is_some() {
-                    info!("Removed stale persisted norestore attribute {name} from config");
-                    config.write();
-                }
-                info!("Reload called on norestore attribute {name}: doing nothing");
+                info!("Reload called on {prop_type:?} attribute {name}: doing nothing");
                 AttrValue::None
             }
             _ => {
@@ -323,34 +308,71 @@ impl AsusArmouryAttribute {
     }
 
     async fn restore_default(&self) -> fdo::Result<()> {
-        self.attr.restore_default()?;
-        if self.name().property_type() == FirmwareAttributeType::Ppt {
-            let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
-            let power_plugged = self
-                .power
-                .get_online()
-                .map_err(|e| {
-                    error!("Could not get power status: {e:?}");
-                    e
-                })
-                .unwrap_or_default();
+        let name = self.attr.name();
+        let prop_type = self.name().property_type();
 
-            let mut config = self.config.lock().await;
-            let tuning = config.select_tunings(power_plugged == 1, profile);
-            if let Some(tune) = tuning.group.get_mut(&self.name()) {
-                if let AttrValue::Integer(i) = self.attr.default_value() {
-                    *tune = *i;
-                }
-            }
-            if tuning.enabled {
-                self.attr
-                    .set_current_value(self.attr.default_value())
+        if prop_type.is_read_only() {
+            warn!(
+                "Attempted to restore default on read-only attribute {name}: operation discarded"
+            );
+            return Err(fdo::Error::NotSupported(format!(
+                "{name} is read-only and cannot be changed"
+            )));
+        }
+
+        match prop_type {
+            FirmwareAttributeType::Ppt => {
+                let profile: PlatformProfile = self.platform.get_platform_profile()?.into();
+                let power_plugged = self
+                    .power
+                    .get_online()
                     .map_err(|e| {
-                        error!("Could not set value: {e:?}");
+                        error!("Could not get power status: {e:?}");
                         e
-                    })?;
+                    })
+                    .unwrap_or_default();
+
+                let default = self.attr.default_value();
+                let mut config = self.config.lock().await;
+                let tuning = config.select_tunings(power_plugged == 1, profile);
+
+                if tuning.enabled {
+                    match self.attr.set_current_value(default) {
+                        Ok(()) => {
+                            if let AttrValue::Integer(i) = default {
+                                if let Some(tune) = tuning.group.get_mut(&self.name()) {
+                                    *tune = *i;
+                                } else {
+                                    tuning.group.insert(self.name(), *i);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to restore default value {:?} for {name}: {e}. Querying active current_value.",
+                                default
+                            );
+                            if let Ok(AttrValue::Integer(cur)) = self.attr.current_value() {
+                                if let Some(tune) = tuning.group.get_mut(&self.name()) {
+                                    *tune = cur;
+                                } else {
+                                    tuning.group.insert(self.name(), cur);
+                                }
+                            }
+                        }
+                    }
+                } else if let AttrValue::Integer(i) = default {
+                    if let Some(tune) = tuning.group.get_mut(&self.name()) {
+                        *tune = *i;
+                    } else {
+                        tuning.group.insert(self.name(), *i);
+                    }
+                }
+                config.write();
             }
-            config.write();
+            _ => {
+                self.attr.restore_default()?;
+            }
         }
         Ok(())
     }
@@ -677,7 +699,8 @@ pub async fn set_config_or_default(
     let mut changed = false;
     for attr in attrs.attributes().iter() {
         let name: FirmwareAttribute = attr.name().into();
-        match name.property_type() {
+        let prop_type = name.property_type();
+        match prop_type {
             FirmwareAttributeType::Ppt => {
                 let tuning = config.select_tunings(power_plugged, profile);
                 if !tuning.enabled {
@@ -722,36 +745,14 @@ pub async fn set_config_or_default(
                     }
                 }
             }
-            FirmwareAttributeType::Gpu => {
-                // Clean stale persisted queue from older versions. GPU deferred
-                // writes are now in-memory and are applied only on shutdown.
+            _ if !prop_type.should_persist_armoury_setting() => {
                 if config.armoury_settings.remove(&name).is_some() {
                     info!(
-                        "Removed stale persisted GPU attribute {} from config",
+                        "Removed stale persisted {prop_type:?} attribute {} from config",
                         <&str>::from(name)
                     );
                     changed = true;
                 }
-            }
-            FirmwareAttributeType::ReadOnly => {
-                if config.armoury_settings.remove(&name).is_some() {
-                    info!(
-                        "Removed stale persisted read-only attribute {} from config",
-                        <&str>::from(name)
-                    );
-                    changed = true;
-                }
-                // Never restore or apply read-only attributes
-            }
-            FirmwareAttributeType::Norestore => {
-                if config.armoury_settings.remove(&name).is_some() {
-                    info!(
-                        "Removed stale persisted norestore attribute {} from config",
-                        <&str>::from(name)
-                    );
-                    changed = true;
-                }
-                // Never restore or apply norestore attributes
             }
             _ => {
                 if let Some(saved_value) = config.armoury_settings.get(&name) {

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -786,10 +786,21 @@ impl CtrlPlatform {
                             .get(&name)
                             .map(|v| AttrValue::Integer(*v))
                             .unwrap_or_else(|| attr.default_value().clone());
-                        // restore default
-                        attr.set_current_value(&value)?;
-                        if let AttrValue::Integer(i) = value {
-                            *tune = i
+                        match attr.set_current_value(&value) {
+                            Ok(()) => {
+                                if let AttrValue::Integer(i) = value {
+                                    *tune = i;
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Could not set PPT value {value:?} for {}: {e}. Querying active current_value.",
+                                    <&str>::from(name)
+                                );
+                                if let Ok(AttrValue::Integer(cur)) = attr.current_value() {
+                                    *tune = cur;
+                                }
+                            }
                         }
                     }
                 }

--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -265,6 +265,16 @@ pub enum FirmwareAttributeType {
     Norestore,
 }
 
+impl FirmwareAttributeType {
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, Self::ReadOnly)
+    }
+
+    pub fn should_persist_armoury_setting(&self) -> bool {
+        matches!(self, Self::Immediate | Self::Bios)
+    }
+}
+
 macro_rules! define_attribute_getters {
     // Accept a list of attribute idents and an optional `types { .. }` block
     ( $( $attr:ident ),* $(,)? $( ; types { $( $tattr:ident : $ptype:ident ),* $(,)? } )? ) => {

--- a/rog-platform/src/asus_armoury.rs
+++ b/rog-platform/src/asus_armoury.rs
@@ -352,7 +352,8 @@ define_attribute_getters!(
 
         apu_mem: Norestore,
 
-        charge_mode: Immediate,
+        // charge_mode is read-only in the asus-armoury driver (0444, no store handler)
+        charge_mode: ReadOnly,
     }
 );
 


### PR DESCRIPTION
# Description

This PR builds on top of #300 and needs #325 as well to simplify and clean up armoury attribute persistence, stale config purging, and `restore_default` handling.

### Key Changes:

- **`rog-platform` (FirmwareAttributeType)**:
  - Added helper methods `is_read_only(&self) -> bool` and `should_persist_armoury_setting(&self) -> bool` on `FirmwareAttributeType` to centralize attribute category classification.
- **`asusd` (Armoury Controller)**:
  - **Deduplication**: Replaced duplicate cleanup blocks for `Gpu`, `ReadOnly`, and `Norestore` across `reload()` and `set_config_or_default()` with a single check against `!prop_type.should_persist_armoury_setting()`.
  - **`restore_default` Refactoring**: Streamlined `restore_default` to safely reject operations on `ReadOnly` attributes, remove redundant duplicate sysfs writes, and query active `current_value` if the firmware rejects the static default in the current power state.

# Verification and testing:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)