### PR TITLE
Add Aura support for ROG Strix G16 G614PP

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -450,6 +450,15 @@
         power_zones: [Keyboard, Lightbar, Logo],
     ),
     (
+        device_name: "G614PP",
+        product_id: "19b6",
+        layout_name: "g634j-per-key",
+        basic_modes: [Static, Breathe, RainbowCycle, RainbowWave, Pulse],
+        basic_zones: [],
+        advanced_type: PerKey,
+        power_zones: [Keyboard, Lightbar],
+    ),
+    (
         device_name: "G614PR",
         product_id: "",
         layout_name: "g614pr-per-key",


### PR DESCRIPTION
# Description

Adds Aura support for ASUS ROG Strix G16 G614PP laptop.
Manually verified by comparing to Armoury Crate available Aura features on Windows.
The configuration works when loaded locally into ROG Control Center as well.
Manually verified that all other modes except the ones listed in the entry are unsupported.
This model doesn't seem to have "basic zones".
Extracted `product_id` value properly using `lsusb`.
The configuration is almost identical to G614PR, but I've decided to omit `basic_zones` because they seem to have no effect (I have no idea what they do when per-key lighting is supported).

Fixes # (issue)

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Strix G16 G614PP-S5063.
- **Linux Distribution:** EndeavourOS.
- **Kernel Version:** `6.18.44-1-lts`, `7.1.8-arch1-3`, and `7.2.0-rc7-1-ogc`.

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
