### PR TITLE
chore: bump rust to 1.85.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "6.4.0"
-rust-version = "1.82"
+rust-version = "1.85"
 license = "MPL-2.0"
 readme = "README.md"
 authors = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.85.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue(if applicable). -->
<!-- If this PR introduces a new feature, explain your motivation and the use case. -->
Bump asusctl from 1.82 to 1.85
Follow-Up PR to come:
- upgrade to edition 2024

## Tested Hardware & Environment

- **ASUS Laptop Model:**
- **Linux Distribution: NixOS**
- **Kernel Version:**

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
