### PR TITLE
refactor: unify image and animation decoding under image crate and add zero-width validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,8 +272,8 @@ dependencies = [
  "argh",
  "dmi_id",
  "env_logger",
+ "image",
  "log",
- "png 0.18.1",
  "rog_anime",
  "rog_aura",
  "rog_dbus",
@@ -3937,15 +3937,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parsenic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c695d2b8bcf1dd62a5173a9c43e6ebbe9261701c002f9b462fc9690c144bb61"
-dependencies = [
- "traitful",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,12 +4016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pix"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6574ffbea793ab0c9a9b09ae99831f1513fdd7732b12aca4c7182c46dc3bc9f"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,19 +4051,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "png_pong"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a767b8b17e388cb7f1e74cf3c2ebce14e6b7ae123fa27150889a353fd9eb981f"
-dependencies = [
- "miniz_oxide",
- "parsenic",
- "pix",
- "simd-adler32",
- "traitful",
 ]
 
 [[package]]
@@ -4555,11 +4527,9 @@ name = "rog_anime"
 version = "6.4.0"
 dependencies = [
  "dmi_id",
- "gif 0.14.2",
  "glam",
+ "image",
  "log",
- "pix",
- "png_pong",
  "serde",
  "thiserror 2.0.20",
  "zbus",
@@ -5786,17 +5756,6 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
-]
-
-[[package]]
-name = "traitful"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d856e22ead1fb79b9fc3cec63300086f680924f2f7b0e2701f6835a28b9c4425"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,13 @@ env_logger = { version = "^0.11.11", default-features = false, features = ["auto
 # by slint 1.13.1
 fontdue = "=0.9.3"
 futures-util = "^0.3.33"
-gif = "^0.14.2"
 glam = { version = "^0.33.2", features = ["serde"] }
-image = "=0.25.9"
+image = { version = "=0.25.9", default-features = false, features = [
+  "png",
+  "gif",
+  "jpeg",
+  "webp",
+] }
 inotify = "^0.11.4"
 ksni = { version = "^0.3.6", default-features = false, features = ["async-io"] }
 libc = "^0.2.189"
@@ -57,9 +61,6 @@ mio = "^1.2.2"
 # z = ["zbus", "serde", "async"]
 notify-rust = { version = "=4.17.0", default-features = false, features = ["z"] }
 nvml-wrapper = "^0.12.1"
-pix = "=0.13.4"
-png = "^0.18.1"
-png_pong = "=0.9.3"
 ron = "^0.12.2"
 rusb = "^0.9.4"
 sdl2 = { version = "^0.38.0", default-features = false }

--- a/asusctl/Cargo.toml
+++ b/asusctl/Cargo.toml
@@ -27,7 +27,7 @@ argh.workspace = true
 
 [dev-dependencies]
 rog_dbus = { path = "../rog-dbus" }
-png.workspace = true
+image.workspace = true
 
 [package.metadata.deb]
 license-file = ["../LICENSE", "4"]

--- a/asusctl/examples/anime-test-patterns.rs
+++ b/asusctl/examples/anime-test-patterns.rs
@@ -11,18 +11,15 @@
 //! Push each pattern to the matrix with:
 //!     asusctl anime pixel-image --path /tmp/g635l-patterns/<pattern>.png
 
-use std::fs::{self, File};
-use std::io::BufWriter;
-use std::path::PathBuf;
-
-use png::{BitDepth, ColorType, Encoder};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 const WIDTH: u32 = 68;
 const HEIGHT: u32 = 34;
 const OUT_DIR: &str = "/tmp/g635l-patterns";
 
 /// Writes an 8-bit grayscale PNG. White = 0xff, black = 0x00.
-fn write_png(path: &PathBuf, pixels: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+fn write_png(path: &Path, pixels: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(
         pixels.len(),
         (WIDTH * HEIGHT) as usize,
@@ -30,12 +27,7 @@ fn write_png(path: &PathBuf, pixels: &[u8]) -> Result<(), Box<dyn std::error::Er
         WIDTH * HEIGHT
     );
 
-    let file = File::create(path)?;
-    let mut encoder = Encoder::new(BufWriter::new(file), WIDTH, HEIGHT);
-    encoder.set_color(ColorType::Grayscale);
-    encoder.set_depth(BitDepth::Eight);
-    let mut writer = encoder.write_header()?;
-    writer.write_image_data(pixels)?;
+    image::save_buffer(path, pixels, WIDTH, HEIGHT, image::ExtendedColorType::L8)?;
     Ok(())
 }
 

--- a/rog-anime/Cargo.toml
+++ b/rog-anime/Cargo.toml
@@ -22,9 +22,7 @@ name = "rog_anime"
 path = "src/lib.rs"
 
 [dependencies]
-png_pong.workspace = true
-pix.workspace = true
-gif.workspace = true
+image.workspace = true
 log.workspace = true
 
 serde.workspace = true

--- a/rog-anime/src/data.rs
+++ b/rog-anime/src/data.rs
@@ -4,7 +4,7 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use dmi_id::DMIID;
-use log::info;
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "dbus")]
 use zbus::zvariant::{OwnedValue, Type, Value};
@@ -317,7 +317,7 @@ pub fn run_animation(frames: &AnimeGif, callback: &dyn Fn(AnimeDataBuffer) -> Re
         fade_out_step = 1.0 / fade_out.as_secs_f32();
 
         if time.total_fade_time() > run_time {
-            println!("Total fade in/out time larger than gif run time. Setting fades to half");
+            warn!("Total fade in/out time larger than gif run time. Setting fades to half");
             fade_in = run_time / 2;
             fade_in_step = 1.0 / (run_time / 2).as_secs_f32();
 

--- a/rog-anime/src/diagonal.rs
+++ b/rog-anime/src/diagonal.rs
@@ -7,18 +7,19 @@ use log::error;
 use crate::AnimeType;
 use crate::data::AnimeDataBuffer;
 use crate::error::{AnimeError, Result};
+use crate::image::Pixel;
 
 /// Mostly intended to be used with ASUS gifs, but can be used for other
 /// purposes (like images)
+#[derive(Clone, Debug)]
 pub struct AnimeDiagonal(AnimeType, Vec<Vec<u8>>);
 
 impl AnimeDiagonal {
+    /// Initialise a new matrix with 0's
     #[inline]
     pub fn new(anime_type: AnimeType) -> Self {
-        Self(
-            anime_type,
-            vec![vec![0; anime_type.width()]; anime_type.height()],
-        )
+        let matrix = vec![vec![0; anime_type.width()]; anime_type.height()];
+        Self(anime_type, matrix)
     }
 
     #[inline]
@@ -38,98 +39,33 @@ impl AnimeDiagonal {
         buf
     }
 
-    /// Generate the base image from inputs. The result can be displayed as is
-    /// or updated via scale, position, or angle then displayed again after
-    /// `update()`.
-    #[inline]
+    /// Make a diagonal matrix from a PNG file.
+    ///
+    /// Accepts PNGs of dimensions up to the max for the laptop model.
+    /// For the G14, the max dimensions are 74x36. Returns [`AnimeError::IncorrectSize`]
+    /// if the image width or height exceeds the supported bounds.
     pub fn from_png(path: &Path, bright: f32, anime_type: AnimeType) -> Result<Self> {
-        let data = std::fs::read(path).map_err(|e| {
+        let img = image::open(path).inspect_err(|e| {
             error!("Could not open {path:?}: {e:?}");
-            e
         })?;
-        let data = std::io::Cursor::new(data);
-        let decoder = png_pong::Decoder::new(data)?.into_steps();
-        let png_pong::Step { raster, delay: _ } = decoder.last().ok_or(AnimeError::NoFrames)??;
+        let rgba = img.to_rgba8();
+
+        let max_w = anime_type.width() as u32;
+        let max_h = anime_type.height() as u32;
+        if rgba.width() > max_w || rgba.height() > max_h {
+            return Err(AnimeError::IncorrectSize(max_w, max_h));
+        }
 
         let mut matrix = AnimeDiagonal::new(anime_type);
 
-        match &raster {
-            png_pong::PngRaster::Gray8(ras) => {
-                Self::pixels_from_8bit(ras, &mut matrix, bright, true);
-            }
-            png_pong::PngRaster::Graya8(ras) => {
-                Self::pixels_from_8bit(ras, &mut matrix, bright, true);
-            }
-            png_pong::PngRaster::Rgb8(ras) => {
-                Self::pixels_from_8bit(ras, &mut matrix, bright, false);
-            }
-            png_pong::PngRaster::Rgba8(ras) => {
-                Self::pixels_from_8bit(ras, &mut matrix, bright, false);
-            }
-            png_pong::PngRaster::Gray16(ras) => {
-                Self::pixels_from_16bit(ras, &mut matrix, bright, true);
-            }
-            png_pong::PngRaster::Rgb16(ras) => {
-                Self::pixels_from_16bit(ras, &mut matrix, bright, false);
-            }
-            png_pong::PngRaster::Graya16(ras) => {
-                Self::pixels_from_16bit(ras, &mut matrix, bright, true);
-            }
-            png_pong::PngRaster::Rgba16(ras) => {
-                Self::pixels_from_16bit(ras, &mut matrix, bright, false);
-            }
-            png_pong::PngRaster::Palette(..) => return Err(AnimeError::Format),
-        };
+        for (x, y, px) in rgba.enumerate_pixels() {
+            let x = x as usize;
+            let y = y as usize;
+            let v = Pixel::from(px).color as f32;
+            matrix.1[y][x] = (v * bright) as u8;
+        }
 
         Ok(matrix)
-    }
-
-    fn pixels_from_8bit<P>(
-        ras: &pix::Raster<P>,
-        matrix: &mut AnimeDiagonal,
-        bright: f32,
-        grey: bool,
-    ) where
-        P: pix::el::Pixel<Chan = pix::chan::Ch8>,
-    {
-        let width = ras.width();
-        for (y, row) in ras.pixels().chunks(width as usize).enumerate() {
-            for (x, px) in row.iter().enumerate() {
-                let v = if grey {
-                    <u8>::from(px.one()) as f32
-                } else {
-                    (<u8>::from(px.one()) / 3) as f32
-                        + (<u8>::from(px.two()) / 3) as f32
-                        + (<u8>::from(px.three()) / 3) as f32
-                };
-                if y < matrix.1.len() && x < matrix.1[y].len() {
-                    matrix.1[y][x] = (v * bright) as u8;
-                }
-            }
-        }
-    }
-
-    fn pixels_from_16bit<P>(
-        ras: &pix::Raster<P>,
-        matrix: &mut AnimeDiagonal,
-        bright: f32,
-        grey: bool,
-    ) where
-        P: pix::el::Pixel<Chan = pix::chan::Ch16>,
-    {
-        let width = ras.width();
-        for (y, row) in ras.pixels().chunks(width as usize).enumerate() {
-            for (x, px) in row.iter().enumerate() {
-                let v = if grey {
-                    (<u16>::from(px.one()) >> 8) as f32
-                } else {
-                    ((<u16>::from(px.one()) / 3) >> 8) as f32
-                        + ((<u16>::from(px.two()) / 3) >> 8) as f32
-                        + ((<u16>::from(px.three()) / 3) >> 8) as f32
-                };
-                matrix.1[y][x] = (v * bright) as u8;
-            }
-        }
     }
 
     /// Convert to a data buffer that can be sent over dbus
@@ -455,5 +391,30 @@ impl AnimeDiagonal {
         let mut buf = vec![0u8; anime_type.data_length()];
         Self::pack_strix_diagonal_into(&mut buf, &self.1);
         AnimeDataBuffer::from_vec(anime_type, buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn test_from_png_oversized_error() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data/ga401-diagonal.png");
+
+        let res = AnimeDiagonal::from_png(&path, 1.0, AnimeType::G835L);
+        assert!(matches!(res, Err(AnimeError::IncorrectSize(68, 34))));
+    }
+
+    #[test]
+    fn test_from_png_valid() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data/ga401-diagonal.png");
+
+        let res = AnimeDiagonal::from_png(&path, 1.0, AnimeType::GA401);
+        assert!(res.is_ok());
     }
 }

--- a/rog-anime/src/error.rs
+++ b/rog-anime/src/error.rs
@@ -1,23 +1,19 @@
-use gif::DecodingError;
-use png_pong::decode::Error as PngError;
+use image::ImageError;
 
 pub type Result<T> = std::result::Result<T, AnimeError>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum AnimeError {
-    #[error("No frames in PNG")]
+    #[error("No frames in image")]
     NoFrames,
 
     #[error("Could not open: {0}")]
-    Io(#[source] std::io::Error),
+    Io(#[from] std::io::Error),
 
-    #[error("PNG error: {0}")]
-    Png(#[source] PngError),
+    #[error("Image error: {0}")]
+    Image(#[from] ImageError),
 
-    #[error("GIF error: {0}")]
-    Gif(#[source] DecodingError),
-
-    #[error("PNG file is not 8bit greyscale")]
+    #[error("Image file format error")]
     Format,
 
     #[error("The input image size is incorrect, expected {0}x{1}")]
@@ -38,6 +34,9 @@ pub enum AnimeError {
     #[error("Image brightness must be between 0.0 and 1.0 (inclusive), was {0}")]
     InvalidBrightness(f32),
 
+    #[error("Image width cannot be zero")]
+    ZeroWidth,
+
     #[error("The data buffer was incorrect length for generating USB packets")]
     DataBufferLength,
 
@@ -49,24 +48,6 @@ pub enum AnimeError {
 
     #[error("Could not parse {0}")]
     ParseError(String),
-}
-
-impl From<std::io::Error> for AnimeError {
-    fn from(err: std::io::Error) -> Self {
-        AnimeError::Io(err)
-    }
-}
-
-impl From<PngError> for AnimeError {
-    fn from(err: PngError) -> Self {
-        AnimeError::Png(err)
-    }
-}
-
-impl From<DecodingError> for AnimeError {
-    fn from(err: DecodingError) -> Self {
-        AnimeError::Gif(err)
-    }
 }
 
 impl From<AnimeError> for zbus::fdo::Error {

--- a/rog-anime/src/gif.rs
+++ b/rog-anime/src/gif.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use glam::Vec2;
+use image::ImageDecoder;
 use log::error;
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +55,21 @@ impl Default for AnimTime {
     }
 }
 
+impl AnimTime {
+    /// Calculate the frame count for a static image with 30ms frame delay
+    #[inline]
+    pub fn static_frame_count(&self) -> usize {
+        let mut total = Duration::from_millis(1000);
+        if let AnimTime::Fade(fade) = self {
+            total = fade.total_fade_time();
+            if let Some(middle) = fade.show_for {
+                total += middle;
+            }
+        }
+        (total.as_millis() / 30).max(1) as usize
+    }
+}
+
 /// Fancy brightness control: fade in/out, show at brightness for n time
 #[derive(Debug, Copy, Clone, Deserialize, Serialize)]
 pub struct Fade {
@@ -88,6 +104,16 @@ impl Fade {
     }
 }
 
+fn decode_gif(file_name: &Path) -> Result<(image::Frames<'static>, u32, u32)> {
+    let file = File::open(file_name).inspect_err(|e| {
+        error!("Could not open {file_name:?}: {e:?}");
+    })?;
+    let mut decoder = image::codecs::gif::GifDecoder::new(std::io::BufReader::new(file))?;
+    decoder.set_limits(image::Limits::default())?;
+    let (width, height) = decoder.dimensions();
+    Ok((image::AnimationDecoder::into_frames(decoder), width, height))
+}
+
 /// A gif animation. This is a collection of frames from the gif, and a duration
 /// that the animation should be shown for.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -104,46 +130,41 @@ impl AnimeGif {
     ) -> Result<Self> {
         let mut matrix = AnimeDiagonal::new(anime_type);
 
-        let mut decoder = gif::DecodeOptions::new();
-        // Configure the decoder such that it will expand the image to RGBA.
-        decoder.set_color_output(gif::ColorOutput::RGBA);
-        // Read the file header
-        let file = File::open(file_name).map_err(|e| {
-            error!("Could not open {file_name:?}: {e:?}");
-            e
-        })?;
-        let mut decoder = decoder.read_info(file)?;
-
         let mut frames = Vec::default();
-        while let Some(frame) = decoder.read_next_frame()? {
-            let wait = frame.delay * 10;
-            // if matches!(frame.dispose, gif::DisposalMethod::Background) {
-            //     frames = Vec::new();
-            // }
-            for (y, row) in frame.buffer.chunks(frame.width as usize * 4).enumerate() {
-                for (x, px) in row.chunks(4).enumerate() {
-                    if px[3] != 255 {
-                        // should be t but not in some gifs? What, ASUS, what?
-                        continue;
-                    }
-                    let tmp = matrix.get_mut();
-                    let y = y + frame.top as usize;
-                    if y >= tmp.len() {
-                        return Err(AnimeError::PixelGifHeight(tmp.len()));
-                    }
-                    let x = x + frame.left as usize;
-                    if x >= tmp[y].len() {
-                        return Err(AnimeError::PixelGifWidth(tmp[y].len()));
-                    }
+        let (frames_iter, _, _) = decode_gif(file_name)?;
+        for frame in frames_iter {
+            let frame = frame?;
+            let wait: Duration = frame.delay().into();
+            let left = frame.left() as usize;
+            let top = frame.top() as usize;
+            let buffer = frame.buffer();
 
-                    matrix.get_mut()[y][x] = (px[0] as f32 * brightness) as u8;
+            for (x, y, px) in buffer.enumerate_pixels() {
+                if px.0[3] != 255 {
+                    // should be t but not in some gifs? What, ASUS, what?
+                    continue;
                 }
+                let tmp = matrix.get_mut();
+                let y = y as usize + top;
+                let x = x as usize + left;
+                if y >= tmp.len() {
+                    return Err(AnimeError::PixelGifHeight(tmp.len()));
+                }
+                if x >= tmp[y].len() {
+                    return Err(AnimeError::PixelGifWidth(tmp[y].len()));
+                }
+
+                let v = Pixel::from(px).color as f32;
+                tmp[y][x] = (v * brightness) as u8;
             }
 
             frames.push(AnimeFrame {
                 data: matrix.into_data_buffer(anime_type)?,
-                delay: Duration::from_millis(wait as u64),
+                delay: wait,
             });
+        }
+        if frames.is_empty() {
+            return Err(AnimeError::NoFrames);
         }
         Ok(Self(frames, duration))
     }
@@ -157,22 +178,13 @@ impl AnimeGif {
         brightness: f32,
     ) -> Result<Self> {
         let image = AnimeDiagonal::from_png(file_name, brightness, anime_type)?;
-
-        let mut total = Duration::from_millis(1000);
-        if let AnimTime::Fade(fade) = duration {
-            total = fade.total_fade_time();
-            if let Some(middle) = fade.show_for {
-                total += middle;
-            }
-        }
-        // Make frame delay 30ms, and find frame count
-        let frame_count = total.as_millis() / 30;
+        let frame_count = duration.static_frame_count();
 
         let single = AnimeFrame {
             data: image.into_data_buffer(anime_type)?,
             delay: Duration::from_millis(30),
         };
-        let frames = vec![single; frame_count as usize];
+        let frames = vec![single; frame_count];
 
         Ok(Self(frames, duration))
     }
@@ -189,66 +201,51 @@ impl AnimeGif {
         brightness: f32,
         anime_type: AnimeType,
     ) -> Result<Self> {
-        let mut frames = Vec::new();
-        let mut decoder = gif::DecodeOptions::new();
-        // Configure the decoder such that it will expand the image to RGBA.
-        decoder.set_color_output(gif::ColorOutput::RGBA);
-        // Read the file header
-        let file = File::open(file_name).map_err(|e| {
-            error!("Could not open {file_name:?}: {e:?}");
-            e
-        })?;
-        let mut decoder = decoder.read_info(file)?;
+        let (frames_iter, width_u32, height_u32) = decode_gif(file_name)?;
+        let width = width_u32 as usize;
+        let height = height_u32 as usize;
 
-        let height = decoder.height();
-        let width = decoder.width();
-        let pixels: Vec<Pixel> =
-            vec![Pixel::default(); (decoder.width() as u32 * decoder.height() as u32) as usize];
-        let mut image = AnimeImage::new(
+        let pixels: Vec<Pixel> = vec![Pixel::default(); width * height];
+        let mut anime_image = AnimeImage::new(
             Vec2::new(scale, scale),
             angle,
             translation,
             brightness,
             pixels,
-            decoder.width() as u32,
+            width_u32,
             anime_type,
         )?;
 
-        while let Some(frame) = decoder.read_next_frame()? {
-            let wait = frame.delay * 10;
-            if matches!(frame.dispose, gif::DisposalMethod::Background) {
-                let pixels: Vec<Pixel> =
-                    vec![Pixel::default(); (width as u32 * height as u32) as usize];
-                image = AnimeImage::new(
-                    Vec2::new(scale, scale),
-                    angle,
-                    translation,
-                    brightness,
-                    pixels,
-                    width as u32,
-                    anime_type,
-                )?;
-            }
-            for (y, row) in frame.buffer.chunks(frame.width as usize * 4).enumerate() {
-                for (x, px) in row.chunks(4).enumerate() {
-                    if px[3] != 255 {
-                        // should be t but not in some gifs? What, ASUS, what?
-                        continue;
-                    }
-                    let pos =
-                        (x + frame.left as usize) + ((y + frame.top as usize) * width as usize);
-                    image.get_mut()[pos] = Pixel {
-                        color: ((px[0] as u32 + px[1] as u32 + px[2] as u32) / 3),
-                        alpha: 1.0,
-                    };
+        let mut frames = Vec::new();
+        for frame in frames_iter {
+            let frame = frame?;
+            let wait: Duration = frame.delay().into();
+            let left = frame.left() as usize;
+            let top = frame.top() as usize;
+            let buffer = frame.buffer();
+
+            for (x, y, px) in buffer.enumerate_pixels() {
+                if px.0[3] != 255 {
+                    // should be t but not in some gifs? What, ASUS, what?
+                    continue;
                 }
+                let px_x = x as usize + left;
+                let px_y = y as usize + top;
+                if px_x >= width || px_y >= height {
+                    continue;
+                }
+                let pos = px_x + px_y * width;
+                anime_image.get_mut()[pos] = Pixel::from(px);
             }
-            image.update();
+            anime_image.update();
 
             frames.push(AnimeFrame {
-                data: <AnimeDataBuffer>::try_from(&image)?,
-                delay: Duration::from_millis(wait as u64),
+                data: <AnimeDataBuffer>::try_from(&anime_image)?,
+                delay: wait,
             });
+        }
+        if frames.is_empty() {
+            return Err(AnimeError::NoFrames);
         }
         Ok(Self(frames, duration))
     }
@@ -269,22 +266,13 @@ impl AnimeGif {
     ) -> Result<Self> {
         let image =
             AnimeImage::from_png(file_name, scale, angle, translation, brightness, anime_type)?;
-
-        let mut total = Duration::from_millis(1000);
-        if let AnimTime::Fade(fade) = duration {
-            total = fade.total_fade_time();
-            if let Some(middle) = fade.show_for {
-                total += middle;
-            }
-        }
-        // Make frame delay 30ms, and find frame count
-        let frame_count = total.as_millis() / 30;
+        let frame_count = duration.static_frame_count();
 
         let single = AnimeFrame {
             data: <AnimeDataBuffer>::try_from(&image)?,
             delay: Duration::from_millis(30),
         };
-        let frames = vec![single; frame_count as usize];
+        let frames = vec![single; frame_count];
 
         Ok(Self(frames, duration))
     }
@@ -308,8 +296,67 @@ impl AnimeGif {
 
     /// Get total gif time for one run
     pub fn total_frame_time(&self) -> Duration {
-        let mut time = 0;
-        self.0.iter().for_each(|f| time += f.delay.as_millis());
-        Duration::from_millis(time as u64)
+        self.0.iter().map(|f| f.delay).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn test_from_gif_custom() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("data/anime/custom/sonic-run.gif");
+
+        let gif = AnimeGif::from_gif(
+            &path,
+            1.0,
+            0.0,
+            Vec2::default(),
+            AnimTime::Infinite,
+            1.0,
+            AnimeType::GA402,
+        )
+        .expect("Failed to decode sonic-run.gif");
+
+        assert!(gif.frame_count() > 0);
+        assert!(gif.total_frame_time() > Duration::ZERO);
+    }
+
+    #[test]
+    fn test_from_diagonal_gif_ga401() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data/ga401-diagonal.gif");
+
+        let gif = AnimeGif::from_diagonal_gif(&path, AnimTime::Count(1), 1.0, AnimeType::GA401)
+            .expect("Failed to decode ga401-diagonal.gif");
+
+        assert_eq!(gif.frame_count(), 1);
+    }
+
+    #[test]
+    fn test_from_diagonal_gif_ga402() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data/ga402-diagonal.gif");
+
+        let gif = AnimeGif::from_diagonal_gif(&path, AnimTime::Count(1), 1.0, AnimeType::GA402)
+            .expect("Failed to decode ga402-diagonal.gif");
+
+        assert_eq!(gif.frame_count(), 1);
+    }
+
+    #[test]
+    fn test_from_diagonal_gif_g835l() {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("tests/data/g835l-diagonal.gif");
+
+        let gif = AnimeGif::from_diagonal_gif(&path, AnimTime::Count(1), 1.0, AnimeType::G835L)
+            .expect("Failed to decode g835l-diagonal.gif");
+
+        // 48 is the expected image-frame count for the g835l-diagonal.gif fixture
+        assert_eq!(gif.frame_count(), 48);
     }
 }

--- a/rog-anime/src/image.rs
+++ b/rog-anime/src/image.rs
@@ -16,6 +16,29 @@ pub struct Pixel {
     pub alpha: f32,
 }
 
+impl Pixel {
+    #[inline]
+    pub const fn from_rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        let color = (r as u32 + g as u32 + b as u32) / 3;
+        let alpha = a as f32 / 255.0;
+        Pixel { color, alpha }
+    }
+}
+
+impl From<image::Rgba<u8>> for Pixel {
+    #[inline]
+    fn from(px: image::Rgba<u8>) -> Self {
+        Self::from_rgba(px[0], px[1], px[2], px[3])
+    }
+}
+
+impl From<&image::Rgba<u8>> for Pixel {
+    #[inline]
+    fn from(px: &image::Rgba<u8>) -> Self {
+        Self::from_rgba(px[0], px[1], px[2], px[3])
+    }
+}
+
 impl Default for Pixel {
     #[inline]
     fn default() -> Self {
@@ -92,6 +115,10 @@ impl AnimeImage {
     ) -> Result<Self> {
         if !(0.0..=1.0).contains(&bright) {
             return Err(AnimeError::InvalidBrightness(bright));
+        }
+
+        if width == 0 {
+            return Err(AnimeError::ZeroWidth);
         }
 
         Ok(Self {
@@ -303,6 +330,7 @@ impl AnimeImage {
         }
     }
 
+    #[inline]
     pub(crate) fn get_mut(&mut self) -> &mut [Pixel] {
         &mut self.img_pixels
     }
@@ -474,50 +502,13 @@ impl AnimeImage {
         bright: f32,
         anime_type: AnimeType,
     ) -> Result<Self> {
-        let data = std::fs::read(path).map_err(|e| {
+        let img = image::open(path).inspect_err(|e| {
             error!("Could not open {path:?}: {e:?}");
-            e
         })?;
-        let data = std::io::Cursor::new(data);
-        let decoder = png_pong::Decoder::new(data)?.into_steps();
-        let png_pong::Step { raster, delay: _ } = decoder.last().ok_or(AnimeError::NoFrames)??;
+        let rgba = img.to_rgba8();
+        let width = rgba.width();
 
-        let width;
-        let pixels = match &raster {
-            png_pong::PngRaster::Gray8(ras) => {
-                width = ras.width();
-                Self::pixels_from_8bit(ras, true)
-            }
-            png_pong::PngRaster::Graya8(ras) => {
-                width = ras.width();
-                Self::pixels_from_8bit(ras, true)
-            }
-            png_pong::PngRaster::Rgb8(ras) => {
-                width = ras.width();
-                Self::pixels_from_8bit(ras, false)
-            }
-            png_pong::PngRaster::Rgba8(ras) => {
-                width = ras.width();
-                Self::pixels_from_8bit(ras, false)
-            }
-            png_pong::PngRaster::Gray16(ras) => {
-                width = ras.width();
-                Self::pixels_from_16bit(ras, true)
-            }
-            png_pong::PngRaster::Rgb16(ras) => {
-                width = ras.width();
-                Self::pixels_from_16bit(ras, false)
-            }
-            png_pong::PngRaster::Graya16(ras) => {
-                width = ras.width();
-                Self::pixels_from_16bit(ras, true)
-            }
-            png_pong::PngRaster::Rgba16(ras) => {
-                width = ras.width();
-                Self::pixels_from_16bit(ras, false)
-            }
-            png_pong::PngRaster::Palette(..) => return Err(AnimeError::Format),
-        };
+        let pixels = rgba.pixels().map(Pixel::from).collect();
 
         let mut matrix = AnimeImage::new(
             Vec2::new(scale, scale),
@@ -532,44 +523,6 @@ impl AnimeImage {
         matrix.update();
         Ok(matrix)
     }
-
-    fn pixels_from_8bit<P>(ras: &pix::Raster<P>, grey: bool) -> Vec<Pixel>
-    where
-        P: pix::el::Pixel<Chan = pix::chan::Ch8>,
-    {
-        ras.pixels()
-            .iter()
-            .map(|px| crate::image::Pixel {
-                color: if grey {
-                    <u8>::from(px.one()) as u32
-                } else {
-                    (<u8>::from(px.one()) / 3) as u32
-                        + (<u8>::from(px.two()) / 3) as u32
-                        + (<u8>::from(px.three()) / 3) as u32
-                },
-                alpha: <f32>::from(px.alpha()),
-            })
-            .collect()
-    }
-
-    fn pixels_from_16bit<P>(ras: &pix::Raster<P>, grey: bool) -> Vec<Pixel>
-    where
-        P: pix::el::Pixel<Chan = pix::chan::Ch16>,
-    {
-        ras.pixels()
-            .iter()
-            .map(|px| crate::image::Pixel {
-                color: if grey {
-                    (<u16>::from(px.one()) >> 8) as u32
-                } else {
-                    ((<u16>::from(px.one()) / 3) >> 8) as u32
-                        + ((<u16>::from(px.two()) / 3) >> 8) as u32
-                        + ((<u16>::from(px.three()) / 3) >> 8) as u32
-                },
-                alpha: <f32>::from(px.alpha()),
-            })
-            .collect()
-    }
 }
 
 impl TryFrom<&AnimeImage> for AnimeDataBuffer {
@@ -578,17 +531,13 @@ impl TryFrom<&AnimeImage> for AnimeDataBuffer {
     /// Do conversion from the nested Vec in `AnimeDataBuffer` to the two
     /// required packets suitable for sending over USB
     fn try_from(leds: &AnimeImage) -> Result<Self> {
-        let mut l: Vec<u8> = leds
-            .led_pos
-            .iter()
-            .map(|l| if let Some(l) = l { l.bright() } else { 0 })
-            .collect();
-        let mut v = Vec::with_capacity(leds.anime_type.data_length());
+        let data_len = leds.anime_type.data_length();
+        let mut v = Vec::with_capacity(data_len);
         if leds.anime_type == AnimeType::GA401 {
             v.push(0);
         }
-        v.append(&mut l);
-        v.append(&mut vec![0u8; leds.anime_type.data_length() - v.len()]);
+        v.extend(leds.led_pos.iter().map(|l| l.map_or(0, |led| led.bright())));
+        v.resize(data_len, 0);
         AnimeDataBuffer::from_vec(leds.anime_type, v)
     }
 }
@@ -688,6 +637,44 @@ mod tests {
         assert_eq!(AnimeImage::pitch(a, 12), 30);
         assert_eq!(AnimeImage::pitch(a, 13), 30);
         assert_eq!(AnimeImage::pitch(a, 14), 29);
+    }
+
+    #[test]
+    fn test_anime_image_new_validation() {
+        let err = AnimeImage::new(
+            Vec2::splat(1.0),
+            0.0,
+            Vec2::default(),
+            1.0,
+            vec![],
+            0,
+            AnimeType::GA402,
+        );
+        assert!(matches!(err, Err(AnimeError::ZeroWidth)));
+
+        let err = AnimeImage::new(
+            Vec2::splat(1.0),
+            0.0,
+            Vec2::default(),
+            1.5,
+            vec![],
+            10,
+            AnimeType::GA402,
+        );
+        assert!(matches!(err, Err(AnimeError::InvalidBrightness(_))));
+    }
+
+    #[test]
+    fn test_pixel_from_rgba() {
+        let rgba = image::Rgba([
+            120, 60, 180, 255,
+        ]);
+        let px1 = Pixel::from(rgba);
+        let px2 = Pixel::from(&rgba);
+        assert_eq!(px1.color, (120 + 60 + 180) / 3);
+        assert_eq!(px1.alpha, 1.0);
+        assert_eq!(px2.color, px1.color);
+        assert_eq!(px2.alpha, px1.alpha);
     }
 
     #[test]


### PR DESCRIPTION
# Description

This PR unifies all image and animation decoding across the workspace under the `image` crate (`image = "=0.25.9"`), removing the direct dependencies on `gif`, `pix`, `png`, and `png_pong`.

### Key Changes:
- **`asusctl`**: Replaced the direct `png` dev-dependency in `examples/anime-test-patterns.rs` with `image::save_buffer`.
- **`rog-anime` (PNG)**: Replaced `png_pong` and `pix` with `image::load_from_memory` and `DynamicImage::to_rgba8()`, eliminating manual matching over `png_pong::PngRaster` variants and adding seamless support for indexed/palette PNGs.
- **`rog-anime` (GIF)**: Replaced the `gif` crate with `image::codecs::gif::GifDecoder` and `image::AnimationDecoder::into_frames`, simplifying frame extraction and ensuring compliant frame compositing.
- **Workspace**: Removed obsolete `png_pong`, `pix`, `png`, and `gif` entries from the root `Cargo.toml`.
- **Image**: dropped all the unused image/video formats. We need only gif, jpeg, PNG and optionally webp for the image we normally use: this way We can reduce the compilation time. We can enable further formats in future if needed.

### Commit Breakdown:
1. `refactor(asusctl): replace png with image in test patterns`
2. `refactor(rog-anime): replace png_pong and pix with image for PNG decoding`
3. `refactor(rog-anime): replace gif crate with image GifDecoder`
4. `chore: remove unused image dependencies from workspace`

## Tested Hardware & Environment

- @luytan let me know if it works

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
