### PR TITLE
feat(asusd): remember platform profile per source

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -93,6 +93,17 @@ asusctl supports setting power profiles via ACPI `platform_profile` drivers.
 >    platform_profile_linked_epp: false,
 >    ```
 
+By default, `asusd` always applies the configured
+`platform_profile_on_ac`/`platform_profile_on_battery` values whenever
+you switch power source. To instead have `asusd` remember the last
+profile you manually selected on each power source and reapply it the
+next time that source becomes active again, enable the following in
+`/etc/asusd/asusd.ron`:
+
+```ron
+remember_platform_profile_per_source: true,
+```
+
 A common use of asusctl is to bind the `fn+f5` (fan) key to `asusctl profile -n` to cycle through the 3 profiles:
 
 1. Balanced

--- a/asusd/src/config.rs
+++ b/asusd/src/config.rs
@@ -44,6 +44,10 @@ pub struct Config {
     pub platform_profile_on_ac: PlatformProfile,
     /// Should the platform profile be set on bat/ac change?
     pub change_platform_profile_on_ac: bool,
+    /// If true, remember the last profile manually selected on each power
+    /// source and restore it on the next switch to that source, instead of
+    /// always applying `platform_profile_on_ac`/`platform_profile_on_battery`
+    pub remember_platform_profile_per_source: bool,
     /// The energy_performance_preference for this platform profile
     pub profile_quiet_epp: CPUEPP,
     /// The energy_performance_preference for this platform profile
@@ -108,6 +112,7 @@ impl Default for Config {
             change_platform_profile_on_battery: true,
             platform_profile_on_ac: PlatformProfile::Performance,
             change_platform_profile_on_ac: true,
+            remember_platform_profile_per_source: false,
             profile_quiet_epp: CPUEPP::Power,
             profile_balanced_epp: CPUEPP::BalancePower,
             profile_performance_epp: CPUEPP::Performance,
@@ -160,6 +165,7 @@ pub struct Config611 {
     pub change_platform_profile_on_battery: bool,
     pub platform_profile_on_ac: PlatformProfile,
     pub change_platform_profile_on_ac: bool,
+    pub remember_platform_profile_per_source: bool,
     pub profile_quiet_epp: CPUEPP,
     pub profile_balanced_epp: CPUEPP,
     pub profile_custom_epp: CPUEPP,
@@ -185,6 +191,7 @@ impl From<Config611> for Config {
             change_platform_profile_on_battery: c.change_platform_profile_on_battery,
             platform_profile_on_ac: c.platform_profile_on_ac,
             change_platform_profile_on_ac: c.change_platform_profile_on_ac,
+            remember_platform_profile_per_source: c.remember_platform_profile_per_source,
             profile_quiet_epp: c.profile_quiet_epp,
             profile_balanced_epp: c.profile_balanced_epp,
             profile_performance_epp: c.profile_performance_epp,
@@ -221,6 +228,7 @@ pub struct Config601 {
     pub change_platform_profile_on_battery: bool,
     pub platform_profile_on_ac: PlatformProfile,
     pub change_platform_profile_on_ac: bool,
+    pub remember_platform_profile_per_source: bool,
     pub profile_quiet_epp: CPUEPP,
     pub profile_balanced_epp: CPUEPP,
     pub profile_performance_epp: CPUEPP,
@@ -258,6 +266,7 @@ impl From<Config601> for Config {
             change_platform_profile_on_battery: c.change_platform_profile_on_battery,
             platform_profile_on_ac: c.platform_profile_on_ac,
             change_platform_profile_on_ac: c.change_platform_profile_on_ac,
+            remember_platform_profile_per_source: c.remember_platform_profile_per_source,
             profile_quiet_epp: c.profile_quiet_epp,
             profile_balanced_epp: c.profile_balanced_epp,
             profile_performance_epp: c.profile_performance_epp,

--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -263,6 +263,34 @@ impl CtrlPlatform {
         }
     }
 
+    /// Remember the given profile as the one to restore next time we switch
+    /// to the currently active power source (AC or battery).
+    async fn remember_profile_for_current_source(&self, policy: PlatformProfile) {
+        let mut config = self.config.lock().await;
+
+        if !config.remember_platform_profile_per_source {
+            return;
+        }
+
+        if let Ok(is_power_plugged) = self
+            .power
+            .get_online()
+            .map(|power_plugged| power_plugged > 0)
+        {
+            match is_power_plugged {
+                true if config.change_platform_profile_on_ac => {
+                    config.platform_profile_on_ac = policy;
+                }
+                false if config.change_platform_profile_on_battery => {
+                    config.platform_profile_on_battery = policy;
+                }
+                _ => return,
+            }
+
+            config.write();
+        }
+    }
+
     async fn get_config_epp_for_throttle(&self, throttle: PlatformProfile) -> CPUEPP {
         match throttle {
             PlatformProfile::Balanced => self.config.lock().await.profile_balanced_epp,
@@ -496,6 +524,7 @@ impl CtrlPlatform {
                     warn!("platform_profile {}", err);
                     FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
                 })?;
+            self.remember_profile_for_current_source(policy).await;
             self.enable_ppt_group_changed(&ctxt).await?;
             Ok(self.platform_profile_changed(&ctxt).await?)
         } else {
@@ -545,6 +574,7 @@ impl CtrlPlatform {
                     warn!("platform_profile {}", err);
                     FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
                 })?;
+            self.remember_profile_for_current_source(policy).await;
             self.enable_ppt_group_changed(&ctxt).await?;
             Ok(())
         } else {
@@ -633,6 +663,42 @@ impl CtrlPlatform {
     async fn set_change_platform_profile_on_ac(&mut self, change: bool) -> Result<(), FdoErr> {
         self.config.lock().await.change_platform_profile_on_ac = change;
         self.config.lock().await.write();
+        Ok(())
+    }
+
+    /// If enabled, the last profile manually selected on a power source is
+    /// remembered and reapplied the next time that source becomes active.
+    #[zbus(property)]
+    async fn remember_platform_profile_per_source(&self) -> Result<bool, FdoErr> {
+        Ok(self
+            .config
+            .lock()
+            .await
+            .remember_platform_profile_per_source)
+    }
+
+    #[zbus(property)]
+    async fn set_remember_platform_profile_per_source(
+        &mut self,
+        remember: bool,
+    ) -> Result<(), FdoErr> {
+        self.config
+            .lock()
+            .await
+            .remember_platform_profile_per_source = remember;
+        self.config.lock().await.write();
+
+        if remember {
+            // `if remember && let Ok(...) = ...` would be more concise,
+            // but let expressions in this position are currently unstable.
+            if let Ok(profile) = self
+                .platform
+                .get_platform_profile()
+                .map(PlatformProfile::from)
+            {
+                self.remember_profile_for_current_source(profile).await;
+            }
+        }
         Ok(())
     }
 

--- a/rog-dbus/src/zbus_platform.rs
+++ b/rog-dbus/src/zbus_platform.rs
@@ -78,6 +78,12 @@ pub trait Platform {
     #[zbus(property)]
     fn set_change_platform_profile_on_ac(&self, change: bool) -> zbus::Result<()>;
 
+    /// RememberPlatformProfilePerSource property
+    #[zbus(property)]
+    fn remember_platform_profile_per_source(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_remember_platform_profile_per_source(&self, remember: bool) -> zbus::Result<()>;
+
     /// ThrottlePolicyOnBattery property
     #[zbus(property)]
     fn platform_profile_on_battery(&self) -> zbus::Result<PlatformProfile>;


### PR DESCRIPTION
# Description

Previously, switching between AC and battery always applied the fixed platform_profile_on_ac/platform_profile_on_battery values, overwriting any profile manually chosen while on that power source.

Introducing new flag: remember_profile_for_current_source

Now, if the flag is true, the last profile manually selected on a given power source is remembered and reapplied the next time that source becomes active.

- Add remember_profile_for_current_source() to persist the active profile into platform_profile_on_ac/battery whenever it's changed via set_platform_profile or next_platform_profile.
- Add remember_platform_profile_per_source config flag (default false) to gate this behavior, with a matching DBus property/setter.
- Enabling the flag immediately captures the current profile for the active power source instead of waiting for the next manual change.
- Expose the new property in the rog-dbus Platform proxy.

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Zephyrus G14 GA403WR_GA403WR
- **Linux Distribution:** Fedora Linux 44
- **Kernel Version:** 7.1.8-200.fc44.x86_64 (64-bit)

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
