### PR TITLE
fix(asusd): avoid redundant no-op writes for GPU firmware attributes

### DIFF
--- a/asusd/src/asus_armoury.rs
+++ b/asusd/src/asus_armoury.rs
@@ -470,6 +470,11 @@ impl AsusArmouryAttribute {
                 }
             }
             FirmwareAttributeType::Gpu => {
+                if self.attr.current_value().ok() == Some(AttrValue::Integer(value)) {
+                    info!("GPU attribute {name} is already {value}, clearing any deferred queue");
+                    self.queued_gpu.lock().await.remove(&self.name());
+                    return Ok(());
+                }
                 debug!("Queueing GPU attribute {name} = {value} for delayed apply");
                 self.queued_gpu.lock().await.insert(self.name(), value);
                 return Ok(());
@@ -565,6 +570,18 @@ impl AsusArmouryAttribute {
             value
         };
 
+        if self.attr.current_value().ok() == Some(AttrValue::Integer(value)) {
+            info!(
+                "Queued GPU attribute {} = {value} is already active, skipping redundant write",
+                <&str>::from(name)
+            );
+            let mut queue = self.queued_gpu.lock().await;
+            if queue.get(&name).copied() == Some(value) {
+                queue.remove(&name);
+            }
+            return Ok(true);
+        }
+
         self.attr
             .set_current_value(&AttrValue::Integer(value))
             .map_err(|e| {
@@ -580,9 +597,12 @@ impl AsusArmouryAttribute {
             <&str>::from(name)
         );
 
-        // Remove only after successful firmware write so transient failures do
-        // not lose deferred shutdown values.
-        self.queued_gpu.lock().await.remove(&name);
+        // Remove only after successful firmware write, and only if the queued
+        // value was not updated concurrently by another call.
+        let mut queue = self.queued_gpu.lock().await;
+        if queue.get(&name).copied() == Some(value) {
+            queue.remove(&name);
+        }
 
         Ok(true)
     }


### PR DESCRIPTION
# Description

ASUS WMI firmware attributes, such as dgpu_disable, return -EIO (I/O error) when writing a value that matches the currently active hardware state. When clients like rog-control-center switch GPU modes (e.g. Ultimate to Hybrid), dgpu_disable=0 is submitted alongside gpu_mux_mode=1.

Previously, asusd used a fire and forget procedure, unconditionally tried to queue both attributes without any real checks. During shutdown, asus-shutdown attempted to write dgpu_disable=0, triggering the kernel -EIO and aborting the deferred batch before gpu_mux_mode could even be applied.

This change introduces two-tier idempotency checks for GPU attributes:
1. In set_current_value: if the requested value already matches the attribute's current sysfs value, do not queue it and clear any previous pending queue.
2. In apply_queued_gpu_value: verify the current value before issuing the sysfs write, skipping redundant writes gracefully.

Fixes #318
Should fix #129 too. Waiting for more context from OP.

## Tested Hardware & Environment

- **ASUS Laptop Model:** G614PR
- **Linux Distribution:** CachyOS
- **Kernel Version:** 7.2

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)