### PR TITLE
feat(asusd): adding battery level custom slash animation (#68)

### DIFF
--- a/asusctl/src/slash_cli.rs
+++ b/asusctl/src/slash_cli.rs
@@ -45,6 +45,8 @@ pub struct SlashSetCommand {
     pub interval: Option<u8>,
     #[argh(option, description = "set SlashMode (use 'list' for options)")]
     pub mode: Option<SlashMode>,
+    #[argh(option, description = "show battery level instead of an animation")]
+    pub battery_level_mode: Option<bool>,
 
     #[argh(option, short = 'B', description = "show the animation on boot")]
     pub show_on_boot: Option<bool>,
@@ -75,6 +77,7 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
         && cmd.show_on_battery.is_none()
         && cmd.show_battery_warning.is_none()
         && cmd.mode.is_none()
+        && cmd.battery_level_mode.is_none()
         && !cmd.enable
         && !cmd.disable
     {
@@ -98,6 +101,9 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
         }
         if let Some(slash_mode) = cmd.mode {
             proxy.set_mode(slash_mode as u8)?;
+        }
+        if let Some(enabled) = cmd.battery_level_mode {
+            proxy.set_battery_level_mode(enabled)?;
         }
         if let Some(show) = cmd.show_on_boot {
             proxy.set_show_on_boot(show)?;
@@ -125,6 +131,7 @@ pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
         let enabled = proxy.enabled()?;
         let brightness = proxy.brightness()?;
         let interval = proxy.interval()?;
+        let battery_level_mode = proxy.battery_level_mode()?;
         let mode_raw = proxy.mode()?;
         let mode_name = SlashMode::try_from(mode_raw)
             .map(|m| m.to_string())
@@ -144,6 +151,14 @@ pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
         );
         println!("Brightness: {}", brightness);
         println!("Interval: {}", interval);
+        println!(
+            "Battery level mode: {}",
+            if battery_level_mode {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
         println!("Mode: {}", mode_name);
         println!("Show on boot: {}", show_on_boot);
         println!("Show on shutdown: {}", show_on_shutdown);

--- a/asusd/src/aura_slash/config.rs
+++ b/asusd/src/aura_slash/config.rs
@@ -13,6 +13,8 @@ pub struct SlashConfig {
     pub brightness: u8,
     pub display_interval: u8,
     pub display_mode: SlashMode,
+    #[serde(default)]
+    pub battery_level_mode: bool,
     pub show_on_boot: bool,
     pub show_on_shutdown: bool,
     pub show_on_sleep: bool,
@@ -28,6 +30,7 @@ impl Default for SlashConfig {
             brightness: 255,
             display_interval: 0,
             display_mode: SlashMode::Bounce,
+            battery_level_mode: false,
             slash_type: SlashType::Unsupported,
             show_on_boot: true,
             show_on_shutdown: true,

--- a/asusd/src/aura_slash/mod.rs
+++ b/asusd/src/aura_slash/mod.rs
@@ -1,21 +1,36 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use config::SlashConfig;
+
+use log::warn;
+
 use rog_platform::hid_raw::HidRaw;
+use rog_platform::power::AsusPower;
 use rog_platform::usb_raw::USBRaw;
-use rog_slash::usb::{slash_pkt_enable, slash_pkt_init, slash_pkt_options, slash_pkt_set_mode};
-use tokio::sync::{Mutex, MutexGuard};
+use rog_slash::usb::{
+    ENHANCED_SEGMENT_COUNT, segment_count, slash_pkt_custom_commit, slash_pkt_custom_enable,
+    slash_pkt_custom_frame, slash_pkt_custom_select, slash_pkt_enable, slash_pkt_init,
+    slash_pkt_options, slash_pkt_set_mode,
+};
+use rog_slash::{SlashType, battery_pattern};
+
+use tokio::sync::{Mutex, MutexGuard, Notify};
+use tokio::task::JoinHandle;
 
 use crate::error::RogError;
 
 pub mod config;
 pub mod trait_impls;
 
+type BatteryLevelTask = (JoinHandle<()>, Arc<Notify>);
+
 #[derive(Debug, Clone)]
 pub struct Slash {
     hid: Option<Arc<Mutex<HidRaw>>>,
     usb: Option<Arc<Mutex<USBRaw>>>,
     config: Arc<Mutex<SlashConfig>>,
+    battery_level_task: Arc<Mutex<Option<BatteryLevelTask>>>,
 }
 
 impl Slash {
@@ -24,7 +39,12 @@ impl Slash {
         usb: Option<Arc<Mutex<USBRaw>>>,
         config: Arc<Mutex<SlashConfig>>,
     ) -> Self {
-        Self { hid, usb, config }
+        Self {
+            hid,
+            usb,
+            config,
+            battery_level_task: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub async fn lock_config(&self) -> MutexGuard<'_, SlashConfig> {
@@ -65,5 +85,88 @@ impl Slash {
         self.write_bytes(&mode_packets[1]).await?;
 
         Ok(())
+    }
+
+    /// Arm the custom-pattern buffer and spawn a background task that renders
+    /// the battery level to it every couple of seconds.
+    pub async fn start_battery_level_task(&self) {
+        let mut task = self.battery_level_task.lock().await;
+        if task.is_some() {
+            return;
+        }
+
+        let slash_type = self.config.lock().await.slash_type;
+
+        let armed = self
+            .write_bytes(&slash_pkt_custom_select(slash_type))
+            .await
+            .and(self.write_bytes(&slash_pkt_custom_enable(slash_type)).await)
+            .and(self.write_bytes(&slash_pkt_custom_commit(slash_type)).await);
+        if let Err(e) = armed {
+            warn!("slash: failed to arm custom-pattern buffer, aborting battery level task: {e}");
+            self.do_initialization().await.ok();
+            return;
+        }
+
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_task = shutdown.clone();
+        let inner = self.clone();
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                let (slash_type, brightness) = {
+                    let config = inner.config.lock().await;
+                    (config.slash_type, config.brightness)
+                };
+                if let Err(e) = inner
+                    .update_slash_battery_level_pattern(slash_type, brightness)
+                    .await
+                {
+                    warn!("slash: failed to update battery level pattern: {e}");
+                }
+                tokio::select! {
+                    _ = shutdown_task.notified() => break,
+                    _ = interval.tick() => {}
+                }
+            }
+        });
+        *task = Some((handle, shutdown));
+    }
+
+    pub async fn update_slash_battery_level_pattern(
+        &self,
+        slash_type: SlashType,
+        brightness: u8,
+    ) -> Result<(), RogError> {
+        let percentage = AsusPower::new()?.get_battery_capacity_percent()?;
+        let length = segment_count(slash_type);
+        let mut segments = [0u8; ENHANCED_SEGMENT_COUNT];
+        battery_pattern(&mut segments[..length], percentage as f32, brightness);
+        let frame = slash_pkt_custom_frame(slash_type, &segments[..length])?;
+
+        self.write_bytes(&frame).await?;
+        Ok(())
+    }
+
+    /// Stop the battery-level background task if running. When `restore_mode`
+    /// is set, also switches the hardware back to the configured
+    /// `display_mode` (skipped when the whole display is being turned off
+    /// anyway, to avoid a redundant write).
+    pub async fn stop_battery_level_task(&self, restore_mode: bool) {
+        let mut task = self.battery_level_task.lock().await;
+        if let Some((handle, shutdown)) = task.take() {
+            shutdown.notify_one();
+            handle.await.ok();
+        }
+        drop(task);
+
+        if restore_mode {
+            // mode-set + save isn't enough to pull the firmware out
+            // of the custom-pattern render target armed by `start_battery_level_task`.
+            let config = self.config.lock().await;
+            for pkt in &slash_pkt_init(config.slash_type) {
+                self.write_bytes(pkt).await.ok();
+            }
+        }
     }
 }

--- a/asusd/src/aura_slash/trait_impls.rs
+++ b/asusd/src/aura_slash/trait_impls.rs
@@ -30,6 +30,9 @@ impl SlashZbus {
         self.reload()
             .await
             .unwrap_or_else(|err| warn!("Controller error: {}", err));
+        if self.0.lock_config().await.battery_level_mode {
+            self.0.start_battery_level_task().await;
+        }
         connection
             .object_server()
             .at(path.clone(), self)
@@ -52,6 +55,9 @@ impl SlashZbus {
     /// Set enabled true or false
     #[zbus(property)]
     async fn set_enabled(&self, enabled: bool) {
+        if !enabled {
+            self.0.stop_battery_level_task(false).await;
+        }
         let mut config = self.0.lock_config().await;
         let brightness = if enabled && config.brightness == 0 {
             0x88
@@ -95,18 +101,29 @@ impl SlashZbus {
     async fn set_brightness(&self, brightness: u8) {
         let mut config = self.0.lock_config().await;
         let enabled = brightness > 0;
-        self.0
-            .write_bytes(&slash_pkt_options(
-                config.slash_type,
-                enabled,
-                brightness,
-                config.display_interval,
-            ))
-            .await
-            .map_err(|err| {
-                warn!("ctrl_slash::set_options {}", err);
-            })
-            .ok();
+
+        if config.battery_level_mode {
+            self.0
+                .update_slash_battery_level_pattern(config.slash_type, brightness)
+                .await
+                .map_err(|err| {
+                    warn!("ctrl_slash::update_slash_battery_level_pattern {}", err);
+                })
+                .ok();
+        } else {
+            self.0
+                .write_bytes(&slash_pkt_options(
+                    config.slash_type,
+                    enabled,
+                    brightness,
+                    config.display_interval,
+                ))
+                .await
+                .map_err(|err| {
+                    warn!("ctrl_slash::set_options {}", err);
+                })
+                .ok();
+        }
 
         config.enabled = enabled;
         config.brightness = brightness;
@@ -149,6 +166,8 @@ impl SlashZbus {
         let mode = SlashMode::try_from(mode).map_err(|err| {
             zbus::fdo::Error::InvalidArgs(format!("ctrl_slash::set_mode {}", err))
         })?;
+        self.0.stop_battery_level_task(true).await;
+
         let mut config = self.0.lock_config().await;
 
         let command_packets = slash_pkt_set_mode(config.slash_type, mode);
@@ -159,8 +178,32 @@ impl SlashZbus {
             .await?;
 
         config.display_mode = mode;
+        config.battery_level_mode = false;
         config.write();
         Ok(())
+    }
+
+    /// Get whether the battery-level fill pattern (software-computed, not a
+    /// hardware `SlashMode`) is currently shown instead of `mode`
+    #[zbus(property)]
+    async fn battery_level_mode(&self) -> bool {
+        let config = self.0.lock_config().await;
+        config.battery_level_mode
+    }
+
+    /// Set whether to show the battery-level fill pattern instead of `mode`.
+    #[zbus(property)]
+    async fn set_battery_level_mode(&self, enabled: bool) {
+        {
+            let mut config = self.0.lock_config().await;
+            config.battery_level_mode = enabled;
+            config.write();
+        }
+        if enabled {
+            self.0.start_battery_level_task().await;
+        } else {
+            self.0.stop_battery_level_task(true).await;
+        }
     }
 
     /// Get the device state as stored by asusd

--- a/asusd/src/error.rs
+++ b/asusd/src/error.rs
@@ -95,6 +95,9 @@ pub enum RogError {
 
     #[error("Parse config error: {0}")]
     ParseRon(#[source] ron::Error),
+
+    #[error("Slash custom pattern buffer not armed")]
+    SlashCustomPatternNotArmed,
 }
 
 impl From<ProfileError> for RogError {

--- a/rog-control-center/src/ui/setup_slash.rs
+++ b/rog-control-center/src/ui/setup_slash.rs
@@ -47,6 +47,7 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
             set_ui_props_async!(handle, slash, SlashPageData, enabled);
             set_ui_props_async!(handle, slash, SlashPageData, brightness);
             set_ui_props_async!(handle, slash, SlashPageData, interval);
+            set_ui_props_async!(handle, slash, SlashPageData, battery_level_mode);
             set_ui_props_async!(handle, slash, SlashPageData, show_on_boot);
             set_ui_props_async!(handle, slash, SlashPageData, show_on_shutdown);
             set_ui_props_async!(handle, slash, SlashPageData, show_on_sleep);
@@ -164,6 +165,13 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                         slash.interval(.try_into().unwrap_or_default()),
                         "Slash interval successfully set to {}",
                         "Setting Slash interval failed"
+                    );
+                    set_ui_callbacks!(
+                        handle,
+                        SlashPageData(),
+                        slash.battery_level_mode(),
+                        "Slash battery level mode successfully set to {}",
+                        "Setting Slash battery level mode failed"
                     );
                     set_ui_callbacks!(
                         handle,

--- a/rog-control-center/ui/pages/slash.slint
+++ b/rog-control-center/ui/pages/slash.slint
@@ -15,6 +15,9 @@ export global SlashPageData {
     in-out property <int> mode: 0;
     callback cb_mode(int);
 
+    in-out property <bool> battery_level_mode: false;
+    callback cb_battery_level_mode(bool);
+
     in-out property <bool> show_on_boot: true;
     callback cb_show_on_boot(bool);
     in-out property <bool> show_on_shutdown: true;
@@ -78,7 +81,7 @@ export component PageSlash inherits Rectangle {
                 minimum: 0;
                 maximum: 5;
                 has_reset: false;
-                enabled <=> SlashPageData.enabled;
+                enabled: SlashPageData.enabled && !SlashPageData.battery_level_mode;
                 value: SlashPageData.interval;
                 released => {
                     SlashPageData.interval = Math.round(self.value);
@@ -91,9 +94,18 @@ export component PageSlash inherits Rectangle {
                 current_index <=> SlashPageData.mode;
                 current_value: SlashPageData.mode_choices[SlashPageData.mode];
                 model <=> SlashPageData.mode_choices;
-                enabled <=> SlashPageData.enabled;
+                enabled: SlashPageData.enabled && !SlashPageData.battery_level_mode;
                 selected => {
                     SlashPageData.cb_mode(SlashPageData.mode);
+                }
+            }
+
+            SystemToggle {
+                text: @tr("Show battery level");
+                checked <=> SlashPageData.battery_level_mode;
+                enabled <=> SlashPageData.enabled;
+                toggled => {
+                    SlashPageData.cb_battery_level_mode(SlashPageData.battery_level_mode);
                 }
             }
 

--- a/rog-dbus/src/zbus_slash.rs
+++ b/rog-dbus/src/zbus_slash.rs
@@ -30,6 +30,13 @@ pub trait Slash {
     #[zbus(property)]
     fn set_mode(&self, value: u8) -> zbus::Result<()>;
 
+    /// BatteryLevelMode property: software-computed battery fill pattern
+    /// instead of a fixed hardware animation
+    #[zbus(property)]
+    fn battery_level_mode(&self) -> zbus::Result<bool>;
+    #[zbus(property)]
+    fn set_battery_level_mode(&self, value: bool) -> zbus::Result<()>;
+
     /// ShowBatteryWarning property
     #[zbus(property)]
     fn show_battery_warning(&self) -> zbus::Result<bool>;

--- a/rog-platform/src/power.rs
+++ b/rog-platform/src/power.rs
@@ -203,6 +203,25 @@ impl AsusPower {
             .map(|w| w as f32)
     }
 
+    /// Current charge level as a percentage (0-100). Prefers the `capacity`
+    /// sysfs attribute (already a percentage); falls back to computing it
+    /// from remaining/full energy or charge for batteries that don't expose
+    /// `capacity`.
+    pub fn get_battery_capacity_percent(&self) -> Result<u8> {
+        if let Ok(capacity) = self.read_battery_attr("capacity") {
+            return Ok(capacity.round().clamp(0.0, 100.0) as u8);
+        }
+        let remaining = self.get_battery_remaining_energy_wh()?;
+        let full = self.get_battery_full_energy_wh()?;
+        if full <= 0.0 {
+            return Err(PlatformError::Read(
+                self.battery.to_string_lossy().into(),
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "full energy is zero"),
+            ));
+        }
+        Ok((remaining / full * 100.0).round().clamp(0.0, 100.0) as u8)
+    }
+
     pub fn get_battery_status(&self) -> Result<String> {
         let path = self.battery.join("status");
         if !path.exists() {

--- a/rog-slash/src/data.rs
+++ b/rog-slash/src/data.rs
@@ -237,3 +237,38 @@ pub struct DeviceState {
     pub slash_interval: u8,
     pub slash_mode: SlashMode,
 }
+
+/// Fills `segments` in place to show `percentage` (0-100) as a bar filled
+/// from the end of the slice backwards, with a single partially-lit
+/// "leading" segment for a smooth edge instead of a hard step between
+/// segments.
+///
+/// `max_brightness` is the value used for fully-lit segments (0-255).
+pub fn battery_pattern(segments: &mut [u8], percentage: f32, max_brightness: u8) {
+    let length = segments.len();
+    segments.fill(0);
+    if length == 0 {
+        return;
+    }
+
+    let percentage = percentage.clamp(0.0, 100.0);
+    let step = 100.0 / length as f32;
+    let bracket = (percentage / step).floor() as usize;
+
+    if bracket >= length {
+        segments.fill(max_brightness);
+        return;
+    }
+
+    // Fully-lit segments, counting backwards from the end of the bar.
+    for seg in segments.iter_mut().skip(length - bracket) {
+        *seg = max_brightness;
+    }
+
+    // Partial "leading" segment: proportional brightness for the remainder.
+    let remainder = percentage - bracket as f32 * step;
+    let partial = (remainder * max_brightness as f32 / step)
+        .round()
+        .clamp(0.0, 255.0) as u8;
+    segments[length - 1 - bracket] = partial;
+}

--- a/rog-slash/src/error.rs
+++ b/rog-slash/src/error.rs
@@ -19,6 +19,9 @@ pub enum SlashError {
 
     #[error("Could not parse {0}")]
     ParseError(String),
+
+    #[error("Invalid segment count: expected {expected}, got {actual}")]
+    SegmentCountMismatch { expected: usize, actual: usize },
 }
 
 impl From<SlashError> for zbus::fdo::Error {

--- a/rog-slash/src/usb.rs
+++ b/rog-slash/src/usb.rs
@@ -8,9 +8,9 @@
 //!
 //! Step 1 needs to be applied only on fresh system boot.
 
-use crate::{SlashMode, SlashType};
+use crate::{SlashMode, SlashType, error::SlashError};
 
-const PACKET_SIZE: usize = 32;
+const PACKET_SIZE: usize = 128;
 const REPORT_ID_193B: u8 = 0x5e;
 const REPORT_ID_19B6: u8 = 0x5d;
 
@@ -20,6 +20,9 @@ pub const PROD_ID1: u16 = 0x193b;
 pub const PROD_ID1_STR: &str = "193B";
 pub const PROD_ID2: u16 = 0x19b6;
 pub const PROD_ID2_STR: &str = "19B6";
+
+pub const BASE_SEGMENT_COUNT: usize = 7;
+pub const ENHANCED_SEGMENT_COUNT: usize = 35;
 
 pub type SlashUsbPacket = [u8; PACKET_SIZE];
 
@@ -184,4 +187,98 @@ pub const fn slash_pkt_lid_closed(slash_type: SlashType, enabled: bool) -> [u8; 
     [
         typ, 0xd8, 0x00, 0x00, 0x02, 0xa5, status,
     ]
+}
+
+// Reverse-engineered by GHelper in `SlashDevice.cs` (Windows). This is
+// NOT part of the Asus fixed `SlashMode` animation set: instead of
+// picking a built-in hardware animation via`slash_pkt_set_mode` the firmware
+// is switched into rendering an arbitrary per-segment brightness buffer
+
+pub const fn segment_count(slash_type: SlashType) -> usize {
+    match slash_type {
+        SlashType::GU605_2024
+        | SlashType::GU605_2025
+        | SlashType::GU606_2026
+        | SlashType::GU405_2026 => ENHANCED_SEGMENT_COUNT,
+        _ => BASE_SEGMENT_COUNT,
+    }
+}
+
+/// Step 1 of arming the custom-pattern region: select region `0xAC`.
+/// Send once when switching into battery-level mode.
+#[inline]
+pub const fn slash_pkt_custom_select(slash_type: SlashType) -> SlashUsbPacket {
+    let mut pkt = [0; PACKET_SIZE];
+    pkt[0] = report_id(slash_type);
+    pkt[1] = 0xd2;
+    pkt[2] = 0x02;
+    pkt[3] = 0x01;
+    pkt[4] = 0x08;
+    pkt[5] = 0xac;
+    pkt
+}
+
+/// Step 2 of arming the custom-pattern region: mark it active.
+#[inline]
+pub const fn slash_pkt_custom_enable(slash_type: SlashType) -> SlashUsbPacket {
+    let mut pkt = [0; PACKET_SIZE];
+    pkt[0] = report_id(slash_type);
+    pkt[1] = 0xd3;
+    pkt[2] = 0x03;
+    pkt[3] = 0x01;
+    pkt[4] = 0x08;
+    pkt[5] = 0xac;
+    pkt[6] = 0xff;
+    pkt[7] = 0xff;
+    pkt[8] = 0x01;
+    pkt[9] = 0x05;
+    pkt[10] = 0xff;
+    pkt[11] = 0xff;
+    pkt
+}
+
+/// Step 3 of arming the custom-pattern region: commit/activate it so the
+/// firmware starts rendering whatever is written by
+/// [`slash_pkt_custom_frame`] instead of a built-in animation.
+#[inline]
+pub const fn slash_pkt_custom_commit(slash_type: SlashType) -> SlashUsbPacket {
+    let mut pkt = [0; PACKET_SIZE];
+    pkt[0] = report_id(slash_type);
+    pkt[1] = 0xd4;
+    pkt[2] = 0x00;
+    pkt[3] = 0x00;
+    pkt[4] = 0x01;
+    pkt[5] = 0xac;
+    pkt
+}
+
+/// Push a raw per-segment brightness frame to the custom-pattern buffer.
+/// Must be preceded (once) by [`slash_pkt_custom_select`] ->
+/// [`slash_pkt_custom_enable`] -> [`slash_pkt_custom_commit`].
+pub fn slash_pkt_custom_frame(
+    slash_type: SlashType,
+    segments: &[u8],
+) -> Result<SlashUsbPacket, SlashError> {
+    let expected = segment_count(slash_type);
+
+    if segments.len() != expected {
+        return Err(SlashError::SegmentCountMismatch {
+            expected,
+            actual: segments.len(),
+        });
+    }
+
+    const HEADER_SIZE: usize = 5;
+    if HEADER_SIZE + segments.len() > PACKET_SIZE {
+        return Err(SlashError::DataBufferLength);
+    }
+
+    let mut pkt = [0; PACKET_SIZE];
+    pkt[0] = report_id(slash_type);
+    pkt[1] = 0xd3;
+    pkt[2] = 0x00;
+    pkt[3] = 0x00;
+    pkt[4] = segments.len() as u8;
+    pkt[5..5 + segments.len()].copy_from_slice(segments);
+    Ok(pkt)
 }

--- a/rog-slash/tests/battery_pattern_tests.rs
+++ b/rog-slash/tests/battery_pattern_tests.rs
@@ -1,0 +1,67 @@
+#[cfg(test)]
+mod battery_pattern_tests {
+    use rog_slash::battery_pattern;
+
+    #[test]
+    fn zero_percent_is_all_dark() {
+        let mut segments = [0u8; 7];
+        battery_pattern(&mut segments, 0.0, 255);
+        assert_eq!(segments, [0u8; 7]);
+    }
+
+    #[test]
+    fn full_percent_is_all_lit() {
+        let mut segments = [0u8; 7];
+        battery_pattern(&mut segments, 100.0, 255);
+        assert_eq!(segments, [255u8; 7]);
+    }
+
+    #[test]
+    fn half_battery_seven_segments() {
+        // step = 100/7 ~= 14.286, bracket = floor(50/14.286) = 3
+        // -> last 3 segments fully lit, segment index 3 partially lit
+        let mut segments = [0u8; 7];
+        battery_pattern(&mut segments, 50.0, 255);
+        assert_eq!(
+            segments,
+            [
+                0, 0, 0, 127, 255, 255, 255
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_length_does_not_panic() {
+        let mut segments: [u8; 0] = [];
+        battery_pattern(&mut segments, 42.0, 255);
+        assert_eq!(segments, [] as [u8; 0]);
+    }
+
+    #[test]
+    fn full_percent_half_brightness() {
+        let mut segments = [0u8; 7];
+        battery_pattern(&mut segments, 100.0, 127);
+        assert_eq!(segments, [127u8; 7]);
+    }
+
+    #[test]
+    fn full_percent_no_brightness() {
+        let mut segments = [1u8; 7];
+        battery_pattern(&mut segments, 100.0, 0);
+        assert_eq!(segments, [0u8; 7]);
+    }
+
+    #[test]
+    fn half_battery_seven_segments_half_brightness() {
+        // step = 100/7 ~= 14.286, bracket = floor(50/14.286) = 3
+        // -> last 3 segments fully lit, segment index 3 partially lit
+        let mut segments = [0u8; 7];
+        battery_pattern(&mut segments, 50.0, 127);
+        assert_eq!(
+            segments,
+            [
+                0, 0, 0, 63, 127, 127, 127
+            ]
+        );
+    }
+}


### PR DESCRIPTION
# Description
Port GHelper's battery slash animation. Computes a per-segment brightness buffer showing battery percentage on Slash bars, plus the custom-pattern USB protocol (select/enable/commit/frame) needed to push it to the device instead of a built-in animation.

## asusd
- `rog-slash/src/data.rs`: adds `battery_pattern(length, percentage, max_brightness)`, used to build the slash pattern based on the user battery level and the `max_brightness`.
- `rog-slash/src/usb.rs`: adds the reverse-engineered "battery level" custom-pattern protocol from GHelper to arm the custom-pattern region, and `slash_pkt_custom_frame` to push a raw per-segment brightness frame. Also adds `segment_count(slash_type)` (7 segments for base models, 35 for enhanced slash GU605/GU606/GU405 models).
-`rog-aura`

**Unverified / needs follow-up:**
- The custom-pattern protocol logic is ported from the reverse-engineered work from GHelper. It have only been checked against real firmware on the 7-segment GA403.
- The 35-segment (GU605/GU606/GU405) comes from GHelper's model list.

## rog-control-center
<img width="1751" height="1035" alt="image" src="https://github.com/user-attachments/assets/fe65289e-87ec-4d54-9883-7b7e2890f9b9" />

- Adding a new toggle called `Show battery level`. If enabled, it disables the `animation` drop-down selection and the `Animation speed`  slider.
- `Brightness` slider remains enable as it can be used to adjust the `Show battery level` LED intensity.

Fixes #68 

## Tested Hardware & Environment

ASUS Laptop Model: ROG Zephyrus G14 GA403WR
Linux Distribution: Fedora Linux 44
Kernel Version: 7.1.8-200.fc44.x86_64 (64-bit)

# TODO
- [ ] Check how this behaves on a 35-segment laptop.

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
