### PR TITLE
refactor(rog-dbus): centralize shared D-Bus connections and typed proxy helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4746,6 +4746,7 @@ dependencies = [
  "rog_profiles",
  "rog_scsi",
  "rog_slash",
+ "tokio",
  "zbus",
 ]
 

--- a/asus-shutdown/src/main.rs
+++ b/asus-shutdown/src/main.rs
@@ -9,11 +9,10 @@ use std::time::Duration;
 use futures_util::StreamExt;
 use log::{debug, error, info, warn};
 use logind_zbus::manager::{InhibitType, ManagerProxy};
-use rog_dbus::asus_armoury::AsusArmouryProxy;
+use rog_dbus::AsusArmouryProxy;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
 use tokio::time::{Instant, sleep};
-use zbus::Connection;
 use zbus::proxy::CacheProperties;
 use zbus::zvariant::OwnedFd;
 
@@ -23,7 +22,6 @@ const WAIT_FOR_GPU_IDLE: Duration = Duration::from_secs(15);
 const GPU_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const GPU_IDLE_STABLE_FOR: Duration = Duration::from_secs(2);
 const ASUSD_BUS_NAME: &str = "xyz.ljones.Asusd";
-const ASUSD_ARMOURY_IFACE: &str = "xyz.ljones.AsusArmoury";
 const ATTR_DGPU_DISABLE: &str = "dgpu_disable";
 const SYSTEMD1_BUS_NAME: &str = "org.freedesktop.systemd1";
 const SYSTEMD1_MANAGER_PATH: &str = "/org/freedesktop/systemd1";
@@ -79,8 +77,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting {}", SERVICE_NAME);
 
-    let connection = Connection::system().await?;
-    let manager = ManagerProxy::builder(&connection)
+    let connection = rog_dbus::system_connection().await?;
+    let manager = ManagerProxy::builder(connection)
         .cache_properties(CacheProperties::No)
         .build()
         .await?;
@@ -175,22 +173,10 @@ async fn print_dry_run_actions() {
 }
 
 async fn fetch_pending_actions() -> Result<Vec<PendingAction>, Box<dyn std::error::Error>> {
-    let conn = Connection::system().await?;
-    let manager = zbus::fdo::ObjectManagerProxy::new(&conn, ASUSD_BUS_NAME, "/").await?;
-    let managed = manager.get_managed_objects().await?;
+    let proxies = rog_dbus::find_armoury_proxies().await?;
 
     let mut actions = Vec::new();
-    for (path, ifaces) in managed {
-        if !ifaces.contains_key(ASUSD_ARMOURY_IFACE) {
-            continue;
-        }
-
-        let proxy = AsusArmouryProxy::builder(&conn)
-            .path(path.clone())?
-            .destination(ASUSD_BUS_NAME)?
-            .build()
-            .await?;
-
+    for proxy in proxies {
         let value = proxy.queued_gpu_value().await?;
         if value < 0 {
             continue;
@@ -198,7 +184,7 @@ async fn fetch_pending_actions() -> Result<Vec<PendingAction>, Box<dyn std::erro
 
         let name = proxy.name().await?;
         actions.push(PendingAction {
-            path: path.to_string(),
+            path: proxy.inner().path().to_string(),
             name: <&str>::from(name).to_owned(),
             value,
         });
@@ -251,9 +237,9 @@ async fn apply_shutdown_settings() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("[phase 5/6] Proceeding with applying deferred GPU settings");
 
-    let conn = Connection::system().await?;
+    let conn = rog_dbus::system_connection().await?;
     for action in queued {
-        let proxy = AsusArmouryProxy::builder(&conn)
+        let proxy = AsusArmouryProxy::builder(conn)
             .path(action.path.as_str())?
             .destination(ASUSD_BUS_NAME)?
             .build()
@@ -341,7 +327,7 @@ async fn wait_for_unit_to_exit(unit_name: &str, timeout: Duration) -> bool {
     );
     let started = Instant::now();
 
-    let conn = match Connection::system().await {
+    let conn = match rog_dbus::system_connection().await {
         Ok(conn) => conn,
         Err(err) => {
             warn!("Failed to connect to system bus while waiting for {unit_name}: {err}");
@@ -350,7 +336,7 @@ async fn wait_for_unit_to_exit(unit_name: &str, timeout: Duration) -> bool {
     };
 
     let manager = match zbus::Proxy::new(
-        &conn,
+        conn,
         SYSTEMD1_BUS_NAME,
         SYSTEMD1_MANAGER_PATH,
         SYSTEMD1_MANAGER_IFACE,
@@ -389,7 +375,7 @@ async fn wait_for_unit_to_exit(unit_name: &str, timeout: Duration) -> bool {
         };
 
         let props_builder =
-            match zbus::fdo::PropertiesProxy::builder(&conn).destination(SYSTEMD1_BUS_NAME) {
+            match zbus::fdo::PropertiesProxy::builder(conn).destination(SYSTEMD1_BUS_NAME) {
                 Ok(builder) => builder,
                 Err(err) => {
                     warn!(
@@ -651,7 +637,10 @@ fn busy_gpu_nodes() -> Result<HashSet<PathBuf>, Box<dyn std::error::Error>> {
 }
 
 fn is_card_entry(name: &str) -> bool {
-    name.starts_with("card") && name[4..].chars().all(|ch| ch.is_ascii_digit())
+    let Some(rest) = name.strip_prefix("card") else {
+        return false;
+    };
+    !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit())
 }
 
 fn read_trimmed(path: impl AsRef<Path>) -> Option<String> {

--- a/asusctl/src/main.rs
+++ b/asusctl/src/main.rs
@@ -13,22 +13,14 @@ use rog_anime::usb::get_anime_type;
 use rog_anime::{AnimTime, AnimeDataBuffer, AnimeDiagonal, AnimeGif, AnimeImage, AnimeType, Vec2};
 use rog_aura::keyboard::{AuraPowerState, LaptopAuraPower};
 use rog_aura::{self, AuraEffect, PowerZones};
-use rog_dbus::asus_armoury::AsusArmouryProxyBlocking;
-use rog_dbus::find_iface_blocking;
 use rog_dbus::list_iface_blocking;
-use rog_dbus::scsi_aura::ScsiAuraProxyBlocking;
-use rog_dbus::zbus_anime::AnimeProxyBlocking;
-use rog_dbus::zbus_aura::AuraProxyBlocking;
-use rog_dbus::zbus_backlight::BacklightProxyBlocking;
-use rog_dbus::zbus_fan_curves::FanCurvesProxyBlocking;
-use rog_dbus::zbus_platform::PlatformProxyBlocking;
+use rog_dbus::{AsusArmouryProxyBlocking, AuraProxyBlocking};
 use rog_platform::asus_armoury::FirmwareAttributeType;
 use rog_platform::platform::{PlatformProfile, Properties};
 use rog_profiles::error::ProfileError;
 use rog_scsi::AuraMode;
 use ron::ser::PrettyConfig;
 use scsi_cli::ScsiCommand;
-use zbus::blocking::Connection;
 
 use crate::cli_opts::*;
 use crate::slash_cli::{
@@ -53,53 +45,49 @@ fn main() {
 
     let parsed: CliStart = argh::from_env();
 
-    let conn = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            error!("Could not connect to D-Bus system bus: {e}\nIs dbus-daemon running?");
-            return;
-        }
-    };
-    if let Ok(platform_proxy) = PlatformProxyBlocking::new(&conn).map_err(|e| {
+    let platform_proxy = match rog_dbus::platform_proxy_blocking().map_err(|e| {
         check_service("asusd");
         println!("\nError: {e}\n");
         print_info();
     }) {
-        let asusd_version = match platform_proxy.version() {
-            Ok(version) => version,
-            Err(e) => {
-                error!(
-                    "Could not get asusd version: {e:?}\nIs asusd.service running? {}",
-                    check_service("asusd")
-                );
-                return;
-            }
-        };
+        Ok(p) => p,
+        Err(_) => return,
+    };
 
-        let self_version = env!("CARGO_PKG_VERSION");
-        if asusd_version != self_version {
-            println!("Version mismatch: asusctl = {self_version}, asusd = {asusd_version}");
+    let asusd_version = match platform_proxy.version() {
+        Ok(version) => version,
+        Err(e) => {
+            error!(
+                "Could not get asusd version: {e:?}\nIs asusd.service running? {}",
+                check_service("asusd")
+            );
             return;
         }
+    };
 
-        let supported_properties = match platform_proxy.supported_properties() {
-            Ok(props) => props,
-            Err(e) => {
-                error!("Could not get supported properties: {e:?}");
-                return;
-            }
-        };
-        let supported_interfaces = match list_iface_blocking() {
-            Ok(ifaces) => ifaces,
-            Err(e) => {
-                error!("Could not get supported interfaces: {e:?}");
-                return;
-            }
-        };
+    let self_version = env!("CARGO_PKG_VERSION");
+    if asusd_version != self_version {
+        println!("Version mismatch: asusctl = {self_version}, asusd = {asusd_version}");
+        return;
+    }
 
-        if let Err(err) = do_parsed(&parsed, &supported_interfaces, &supported_properties, conn) {
-            print_error_help(&*err, &supported_interfaces, &supported_properties);
+    let supported_properties = match platform_proxy.supported_properties() {
+        Ok(props) => props,
+        Err(e) => {
+            error!("Could not get supported properties: {e:?}");
+            return;
         }
+    };
+    let supported_interfaces = match list_iface_blocking() {
+        Ok(ifaces) => ifaces,
+        Err(e) => {
+            error!("Could not get supported interfaces: {e:?}");
+            return;
+        }
+    };
+
+    if let Err(err) = do_parsed(&parsed, &supported_interfaces, &supported_properties) {
+        print_error_help(&*err, &supported_interfaces, &supported_properties);
     }
 }
 
@@ -149,7 +137,6 @@ fn do_parsed(
     parsed: &CliStart,
     supported_interfaces: &[String],
     supported_properties: &[Properties],
-    conn: Connection,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match &parsed.command {
         CliCommand::Aura(a) => match &a.command {
@@ -158,14 +145,14 @@ fn do_parsed(
             crate::cli_opts::AuraSubCommand::Power(pow) => handle_led_power2(pow)?,
         },
         CliCommand::Brightness(cmd) => handle_brightness(cmd)?,
-        CliCommand::Profile(cmd) => handle_throttle_profile(&conn, supported_properties, cmd)?,
-        CliCommand::FanCurve(cmd) => handle_fan_curve(&conn, cmd)?,
+        CliCommand::Profile(cmd) => handle_throttle_profile(supported_properties, cmd)?,
+        CliCommand::FanCurve(cmd) => handle_fan_curve(cmd)?,
         CliCommand::Anime(cmd) => handle_anime(cmd)?,
         CliCommand::Slash(cmd) => handle_slash(cmd)?,
         CliCommand::Scsi(cmd) => handle_scsi(cmd)?,
-        CliCommand::Armoury(cmd) => handle_armoury_command(cmd, &conn)?,
+        CliCommand::Armoury(cmd) => handle_armoury_command(cmd)?,
         CliCommand::Backlight(cmd) => handle_backlight(cmd)?,
-        CliCommand::Battery(cmd) => handle_battery(cmd, &conn)?,
+        CliCommand::Battery(cmd) => handle_battery(cmd)?,
         CliCommand::XgmLed(cmd) => xgm_led_cli::handle_xgm_led(&cmd.command)?,
         CliCommand::Info(info_opt) => {
             handle_info(info_opt, supported_interfaces, supported_properties)?
@@ -175,24 +162,21 @@ fn do_parsed(
     Ok(())
 }
 
-fn handle_battery(
-    cmd: &BatteryCommand,
-    conn: &Connection,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn handle_battery(cmd: &BatteryCommand) -> Result<(), Box<dyn std::error::Error>> {
     match &cmd.command {
         BatterySubCommand::Limit(l) => {
-            let proxy = PlatformProxyBlocking::new(conn)?;
+            let proxy = rog_dbus::platform_proxy_blocking()?;
             proxy.set_charge_control_end_threshold(l.limit)?;
         }
         BatterySubCommand::OneShot(o) => {
-            let proxy = PlatformProxyBlocking::new(conn)?;
+            let proxy = rog_dbus::platform_proxy_blocking()?;
             if let Some(p) = o.percent {
                 proxy.set_charge_control_end_threshold(p)?;
             }
             proxy.one_shot_full_charge()?;
         }
         BatterySubCommand::Info(_) => {
-            let proxy = PlatformProxyBlocking::new(conn)?;
+            let proxy = rog_dbus::platform_proxy_blocking()?;
             let limit = proxy.charge_control_end_threshold()?;
             println!("Current battery charge limit: {}%", limit);
         }
@@ -217,7 +201,7 @@ fn handle_info(
             "Supported Platform Properties:\n{:#?}",
             supported_properties
         );
-        if let Ok(aura) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura") {
+        if let Ok(aura) = rog_dbus::find_aura_proxies_blocking() {
             // TODO: multiple RGB check
             if let Some(first_aura) = aura.first() {
                 let bright = first_aura.supported_brightness()?;
@@ -240,44 +224,40 @@ fn handle_info(
 }
 
 fn handle_backlight(cmd: &BacklightCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let backlight = rog_dbus::backlight_proxy_blocking()?;
+
     if cmd.screenpad_brightness.is_none()
         && cmd.screenpad_gamma.is_none()
         && cmd.sync_screenpad_brightness.is_none()
     {
-        let backlights = find_iface_blocking::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
-        for backlight in backlights {
-            println!("Current screenpad settings:");
-            println!("  Brightness: {}", backlight.screenpad_brightness()?);
-            println!("  Gamma: {}", backlight.screenpad_gamma()?);
-            println!(
-                "  Sync with primary: {}",
-                backlight.screenpad_sync_with_primary()?
-            );
-        }
+        println!("Current screenpad settings:");
+        println!("  Brightness: {}", backlight.screenpad_brightness()?);
+        println!("  Gamma: {}", backlight.screenpad_gamma()?);
+        println!(
+            "  Sync with primary: {}",
+            backlight.screenpad_sync_with_primary()?
+        );
 
         return Ok(());
     }
 
-    let backlights = find_iface_blocking::<BacklightProxyBlocking>("xyz.ljones.Backlight")?;
-    for backlight in backlights {
-        if let Some(brightness) = cmd.screenpad_brightness {
-            backlight.set_screenpad_brightness(brightness)?;
-        }
+    if let Some(brightness) = cmd.screenpad_brightness {
+        backlight.set_screenpad_brightness(brightness)?;
+    }
 
-        if let Some(gamma) = cmd.screenpad_gamma {
-            backlight.set_screenpad_gamma(gamma.to_string().as_str())?;
-        }
+    if let Some(gamma) = cmd.screenpad_gamma {
+        backlight.set_screenpad_gamma(gamma.to_string().as_str())?;
+    }
 
-        if let Some(sync) = cmd.sync_screenpad_brightness {
-            backlight.set_screenpad_sync_with_primary(sync)?;
-        }
+    if let Some(sync) = cmd.sync_screenpad_brightness {
+        backlight.set_screenpad_sync_with_primary(sync)?;
     }
 
     Ok(())
 }
 
 fn handle_brightness(cmd: &BrightnessCommand) -> Result<(), Box<dyn std::error::Error>> {
-    let Ok(aura_proxies) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura") else {
+    let Ok(aura_proxies) = rog_dbus::find_aura_proxies_blocking() else {
         println!("No aura interface found");
         return Ok(());
     };
@@ -332,7 +312,7 @@ fn handle_anime(cmd: &AnimeCommand) -> Result<(), Box<dyn std::error::Error>> {
         println!("Missing arg or command; run 'asusctl anime --help' for usage");
     }
 
-    let animes = find_iface_blocking::<AnimeProxyBlocking>("xyz.ljones.Anime").map_err(|e| {
+    let animes = rog_dbus::find_anime_proxies_blocking().map_err(|e| {
         error!("Did not find any interface for xyz.ljones.Anime: {e:?}");
         e
     })?;
@@ -515,7 +495,7 @@ fn handle_scsi(cmd: &ScsiCommand) -> Result<(), Box<dyn std::error::Error>> {
         println!("Missing arg or command; run 'asusctl scsi --help' for usage");
     }
 
-    let scsis = find_iface_blocking::<ScsiAuraProxyBlocking>("xyz.ljones.ScsiAura")?;
+    let scsis = rog_dbus::find_scsi_aura_proxies_blocking()?;
 
     for scsi in scsis {
         if let Some(enable) = cmd.enable {
@@ -579,7 +559,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
     if mode.command.is_none() && !mode.prev_mode && !mode.next_mode {
         println!("Missing arg or command; run 'asusctl aura --help' for usage");
         // print available modes when possible
-        if let Ok(aura) = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")
+        if let Ok(aura) = rog_dbus::find_aura_proxies_blocking()
             && let Some(first_aura) = aura.first()
         {
             let modes = first_aura.supported_basic_modes()?;
@@ -595,7 +575,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
         println!("Please specify either next or previous");
         return Ok(());
     }
-    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = rog_dbus::find_aura_proxies_blocking()?;
     if mode.next_mode {
         for aura in aura {
             let mode = aura.led_mode()?;
@@ -636,7 +616,7 @@ fn handle_led_mode(mode: &LedModeCommand) -> Result<(), Box<dyn std::error::Erro
 }
 
 fn handle_led_power1(power: &LedPowerCommand1) -> Result<(), Box<dyn std::error::Error>> {
-    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = rog_dbus::find_aura_proxies_blocking()?;
     for aura in aura {
         let dev_type = aura.device_type()?;
         if !dev_type.is_old_laptop() && !dev_type.is_tuf_laptop() {
@@ -693,7 +673,7 @@ fn handle_led_power_1_do_1866(
 }
 
 fn handle_led_power2(power: &LedPowerCommand2) -> Result<(), Box<dyn std::error::Error>> {
-    let aura = find_iface_blocking::<AuraProxyBlocking>("xyz.ljones.Aura")?;
+    let aura = rog_dbus::find_aura_proxies_blocking()?;
     for aura in aura {
         let dev_type = aura.device_type()?;
         if !dev_type.is_new_laptop() {
@@ -753,7 +733,6 @@ fn handle_led_power2(power: &LedPowerCommand2) -> Result<(), Box<dyn std::error:
 }
 
 fn handle_throttle_profile(
-    conn: &Connection,
     supported: &[Properties],
     cmd: &ProfileCommand,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -762,7 +741,7 @@ fn handle_throttle_profile(
         return Err(ProfileError::NotSupported.into());
     }
 
-    let proxy = PlatformProxyBlocking::new(conn)?;
+    let proxy = rog_dbus::platform_proxy_blocking()?;
     let current = proxy.platform_profile()?;
     let choices = proxy.platform_profile_choices()?;
 
@@ -811,11 +790,8 @@ fn handle_throttle_profile(
     Ok(())
 }
 
-fn handle_fan_curve(
-    conn: &Connection,
-    cmd: &FanCurveCommand,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let Ok(fan_proxy) = FanCurvesProxyBlocking::new(conn).map_err(|e| {
+fn handle_fan_curve(cmd: &FanCurveCommand) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(fan_proxy) = rog_dbus::fan_curves_proxy_blocking().map_err(|e| {
         println!("Fan-curves not supported by either this kernel or by the laptop: {e:?}");
     }) else {
         return Err(ProfileError::NotSupported.into());
@@ -836,7 +812,7 @@ fn handle_fan_curve(
         return Ok(());
     }
 
-    let plat_proxy = PlatformProxyBlocking::new(conn)?;
+    let plat_proxy = rog_dbus::platform_proxy_blocking()?;
     if cmd.get_enabled {
         let profile = plat_proxy.platform_profile()?;
         let curves = fan_proxy.fan_curve_data(profile)?;
@@ -984,16 +960,11 @@ fn print_firmware_attr(attr: &AsusArmouryProxyBlocking) -> Result<(), Box<dyn st
 // `unknown_lints` is silenced first so older toolchains (rustc 1.85) don't
 // reject the newer lint names while newer ones still honor them.
 #[allow(unknown_lints, clippy::manual_is_multiple_of, clippy::nonminimal_bool)]
-fn handle_armoury_command(
-    cmd: &ArmouryCommand,
-    conn: &Connection,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn handle_armoury_command(cmd: &ArmouryCommand) -> Result<(), Box<dyn std::error::Error>> {
     // If nested subcommand provided, handle set/get/list.
     match &cmd.command {
         ArmourySubCommand::List(_) => {
-            if let Ok(attrs) =
-                find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
-            {
+            if let Ok(attrs) = rog_dbus::find_armoury_proxies_blocking() {
                 for attr in attrs.iter() {
                     print_firmware_attr(attr)?;
                 }
@@ -1002,7 +973,7 @@ fn handle_armoury_command(
         }
         ArmourySubCommand::Get(g) => {
             let mut found = false;
-            let attrs = find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
+            let attrs = rog_dbus::find_armoury_proxies_blocking()
                 .map_err(|e| format!("Could not reach asusd armoury interface: {e}"))?;
             for attr in attrs.iter() {
                 let name = attr.name()?;
@@ -1018,7 +989,7 @@ fn handle_armoury_command(
         }
         ArmourySubCommand::Set(s) => {
             let mut found = false;
-            let attrs = find_iface_blocking::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury")
+            let attrs = rog_dbus::find_armoury_proxies_blocking()
                 .map_err(|e| format!("Could not reach asusd armoury interface: {e}"))?;
             for attr in attrs.iter() {
                 let name = attr.name()?;
@@ -1032,7 +1003,8 @@ fn handle_armoury_command(
 
                     if attr.name()?.property_type() == FirmwareAttributeType::Ppt {
                         // Only Ok(true) means the value was applied to hardware now
-                        match PlatformProxyBlocking::new(conn).and_then(|p| p.enable_ppt_group()) {
+                        match rog_dbus::platform_proxy_blocking().and_then(|p| p.enable_ppt_group())
+                        {
                             Ok(true) => {}
                             Ok(false) => println!(
                                 "PPT config updated and will be applied when tuning is enabled\n\

--- a/asusctl/src/slash_cli.rs
+++ b/asusctl/src/slash_cli.rs
@@ -1,6 +1,4 @@
 use argh::FromArgs;
-use rog_dbus::find_iface_blocking;
-use rog_dbus::zbus_slash::SlashProxyBlocking;
 use rog_slash::SlashMode;
 
 #[derive(FromArgs, Debug)]
@@ -82,7 +80,7 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
         return Ok(());
     }
 
-    let slashes = find_iface_blocking::<SlashProxyBlocking>("xyz.ljones.Slash")?;
+    let slashes = rog_dbus::find_slash_proxies_blocking()?;
     for proxy in &slashes {
         if cmd.enable {
             proxy.set_enabled(true)?;
@@ -120,7 +118,7 @@ pub fn handle_slash_set(cmd: &SlashSetCommand) -> Result<(), Box<dyn std::error:
 }
 
 pub fn handle_slash_get() -> Result<(), Box<dyn std::error::Error>> {
-    let slashes = find_iface_blocking::<SlashProxyBlocking>("xyz.ljones.Slash")?;
+    let slashes = rog_dbus::find_slash_proxies_blocking()?;
     for proxy in &slashes {
         let enabled = proxy.enabled()?;
         let brightness = proxy.brightness()?;

--- a/asusctl/src/xgm_led_cli.rs
+++ b/asusctl/src/xgm_led_cli.rs
@@ -1,9 +1,7 @@
 use crate::cli_opts::XgmLedSubCommand;
-use rog_dbus::find_iface_blocking;
-use rog_dbus::zbus_xgm_led::XgmLedProxyBlocking;
 
 pub fn handle_xgm_led(cmd: &XgmLedSubCommand) -> Result<(), Box<dyn std::error::Error>> {
-    let xgm_leds = find_iface_blocking::<XgmLedProxyBlocking>("xyz.ljones.XgmLed")?;
+    let xgm_leds = rog_dbus::find_xgm_led_proxies_blocking()?;
 
     for proxy in &xgm_leds {
         match cmd {

--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -71,8 +71,7 @@ fn main() -> Result<()> {
 
     // version checks
     let self_version = env!("CARGO_PKG_VERSION");
-    let zbus_con = rog_dbus::system_connection_blocking()?;
-    let platform_proxy = rog_dbus::zbus_platform::PlatformProxyBlocking::new(zbus_con)?;
+    let platform_proxy = rog_dbus::platform_proxy_blocking()?;
     let asusd_version = match platform_proxy.version() {
         Ok(v) => v,
         Err(e) => {

--- a/rog-control-center/src/main.rs
+++ b/rog-control-center/src/main.rs
@@ -71,8 +71,8 @@ fn main() -> Result<()> {
 
     // version checks
     let self_version = env!("CARGO_PKG_VERSION");
-    let zbus_con = zbus::blocking::Connection::system()?;
-    let platform_proxy = rog_dbus::zbus_platform::PlatformProxyBlocking::new(&zbus_con)?;
+    let zbus_con = rog_dbus::system_connection_blocking()?;
+    let platform_proxy = rog_dbus::zbus_platform::PlatformProxyBlocking::new(zbus_con)?;
     let asusd_version = match platform_proxy.version() {
         Ok(v) => v,
         Err(e) => {

--- a/rog-control-center/src/ui/mod.rs
+++ b/rog-control-center/src/ui/mod.rs
@@ -107,7 +107,7 @@ pub fn show_toast(
             let delayed_handle = handle.clone();
             let delayed_text = fail.clone();
             slint::invoke_from_event_loop(move || {
-                log::warn!("{fail}: {e}");
+                warn!("{fail}: {e}");
                 if let Some(h) = handle.upgrade() {
                     h.invoke_show_toast(fail);
                 }
@@ -164,7 +164,7 @@ pub fn setup_window(
 
     ui.on_exit_app(move || {
         if let Err(e) = slint::quit_event_loop() {
-            log::warn!("Failed to quit event loop: {e:?}");
+            warn!("Failed to quit event loop: {e:?}");
         }
     });
 

--- a/rog-control-center/src/ui/setup_anime.rs
+++ b/rog-control-center/src/ui/setup_anime.rs
@@ -2,8 +2,6 @@ use std::sync::{Arc, Mutex};
 
 use log::{error, info};
 use rog_anime::Animations;
-use rog_dbus::find_iface_async;
-use rog_dbus::zbus_anime::AnimeProxy;
 use slint::ComponentHandle;
 
 use crate::config::Config;
@@ -13,7 +11,7 @@ use crate::{AnimePageData, MainWindow, set_ui_callbacks, set_ui_props_async};
 pub fn setup_anime_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
     let handle = ui.as_weak();
     tokio::spawn(async move {
-        let Ok(animes) = find_iface_async::<AnimeProxy>("xyz.ljones.Anime").await else {
+        let Ok(animes) = rog_dbus::find_anime_proxies().await else {
             info!("This device appears to have no aura interfaces");
             return;
         };

--- a/rog-control-center/src/ui/setup_aura.rs
+++ b/rog-control-center/src/ui/setup_aura.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use log::{debug, error, info};
 use rog_aura::keyboard::LaptopAuraPower;
 use rog_aura::{AuraDeviceType, PowerZones};
-use rog_dbus::zbus_aura::AuraProxy;
+use rog_dbus::AuraProxy;
 use slint::{ComponentHandle, Model, RgbaColor, SharedString};
 
 use crate::config::Config;
@@ -37,10 +37,10 @@ fn decode_hex(s: &str) -> RgbaColor<u8> {
 /// Find and return the primary Aura interface.
 ///
 /// When multiple Aura devices are detected (e.g. built-in laptop keyboard and external
-/// peripherals), `find_iface_async` returns them sorted ascendingly by D-Bus object path.
+/// peripherals), `find_aura_proxies` returns them sorted ascendingly by D-Bus object path.
 /// We select the primary device (the first interface at the lowest path index, e.g. `/xyz/ljones/Aura/0`).
 async fn find_aura_iface() -> Result<AuraProxy<'static>, Box<dyn std::error::Error>> {
-    let ifaces = rog_dbus::find_iface_async::<AuraProxy>("xyz.ljones.Aura").await?;
+    let ifaces = rog_dbus::find_aura_proxies().await?;
     ifaces
         .into_iter()
         .next()

--- a/rog-control-center/src/ui/setup_aura.rs
+++ b/rog-control-center/src/ui/setup_aura.rs
@@ -34,25 +34,17 @@ fn decode_hex(s: &str) -> RgbaColor<u8> {
     }
 }
 
+/// Find and return the primary Aura interface.
+///
+/// When multiple Aura devices are detected (e.g. built-in laptop keyboard and external
+/// peripherals), `find_iface_async` returns them sorted ascendingly by D-Bus object path.
+/// We select the primary device (the first interface at the lowest path index, e.g. `/xyz/ljones/Aura/0`).
 async fn find_aura_iface() -> Result<AuraProxy<'static>, Box<dyn std::error::Error>> {
-    let conn = zbus::Connection::system().await?;
-    let mgr = zbus::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/").await?;
-    let objs = mgr.get_managed_objects().await?;
-    let mut paths: Vec<zbus::zvariant::OwnedObjectPath> = objs
-        .iter()
-        .filter(|(_, ifaces)| ifaces.keys().any(|k| k.as_str() == "xyz.ljones.Aura"))
-        .map(|(p, _)| p.clone())
-        .collect();
-    if paths.len() > 1 {
-        log::debug!("Multiple aura devices: {paths:?}");
-    }
-    let path = paths.pop().ok_or("No Aura interface")?;
-    AuraProxy::builder(&conn)
-        .path(path)?
-        .destination("xyz.ljones.Asusd")?
-        .build()
-        .await
-        .map_err(Into::into)
+    let ifaces = rog_dbus::find_iface_async::<AuraProxy>("xyz.ljones.Aura").await?;
+    ifaces
+        .into_iter()
+        .next()
+        .ok_or_else(|| "No Aura interface".into())
 }
 
 pub async fn prefetch_supported_basic_modes() -> Option<Vec<i32>> {

--- a/rog-control-center/src/ui/setup_fans.rs
+++ b/rog-control-center/src/ui/setup_fans.rs
@@ -101,7 +101,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
 
     tokio::spawn(async move {
         // Create the connections/proxies here to prevent future delays in process
-        let conn = match zbus::Connection::system().await {
+        let conn = match rog_dbus::system_connection().await {
             Ok(conn) => conn,
             Err(e) => {
                 error!("{e:}");
@@ -109,7 +109,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
             }
         };
 
-        let fans = match FanCurvesProxy::new(&conn).await {
+        let fans = match FanCurvesProxy::new(conn).await {
             Ok(fans) => fans,
             Err(e) => {
                 error!("{e:}");
@@ -117,7 +117,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
             }
         };
 
-        let platform = match PlatformProxy::new(&conn).await {
+        let platform = match PlatformProxy::new(conn).await {
             Ok(platform) => platform,
             Err(e) => {
                 error!("{e:}");

--- a/rog-control-center/src/ui/setup_fans.rs
+++ b/rog-control-center/src/ui/setup_fans.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use log::error;
-use rog_dbus::zbus_fan_curves::FanCurvesProxy;
-use rog_dbus::zbus_platform::PlatformProxy;
 use rog_platform::platform::PlatformProfile;
 use rog_profiles::fan_curve_set::CurveData;
 use slint::{ComponentHandle, Model, Weak};
@@ -101,15 +99,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
 
     tokio::spawn(async move {
         // Create the connections/proxies here to prevent future delays in process
-        let conn = match rog_dbus::system_connection().await {
-            Ok(conn) => conn,
-            Err(e) => {
-                error!("{e:}");
-                return;
-            }
-        };
-
-        let fans = match FanCurvesProxy::new(conn).await {
+        let fans = match rog_dbus::fan_curves_proxy().await {
             Ok(fans) => fans,
             Err(e) => {
                 error!("{e:}");
@@ -117,7 +107,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
             }
         };
 
-        let platform = match PlatformProxy::new(conn).await {
+        let platform = match rog_dbus::platform_proxy().await {
             Ok(platform) => platform,
             Err(e) => {
                 error!("{e:}");
@@ -223,10 +213,7 @@ pub fn setup_fan_curve_page(ui: &MainWindow, _config: Arc<Mutex<Config>>) {
 fn fan_data_for(fan: FanType, enabled: bool, data: Vec<Node>) -> CurveData {
     let mut temp = [0u8; 8];
     let mut pwm = [0u8; 8];
-    for (i, n) in data.iter().enumerate() {
-        if i == 8 {
-            break;
-        }
+    for (i, n) in data.iter().take(8).enumerate() {
         temp[i] = n.x as u8;
         pwm[i] = n.y as u8;
     }

--- a/rog-control-center/src/ui/setup_gpu.rs
+++ b/rog-control-center/src/ui/setup_gpu.rs
@@ -351,8 +351,8 @@ pub fn setup_gpu_page(ui: &MainWindow) {
         }
 
         // --- Disable nvidia-powerd on battery ---
-        let platform_proxy = match zbus::Connection::system().await {
-            Ok(conn) => match PlatformProxy::builder(&conn).build().await {
+        let platform_proxy = match rog_dbus::system_connection().await {
+            Ok(conn) => match PlatformProxy::builder(conn).build().await {
                 Ok(p) => p,
                 Err(e) => {
                     error!("setup_gpu: failed to create PlatformProxy: {e:?}");

--- a/rog-control-center/src/ui/setup_gpu.rs
+++ b/rog-control-center/src/ui/setup_gpu.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
 use log::{error, info};
-use rog_dbus::asus_armoury::AsusArmouryProxy;
-use rog_dbus::zbus_platform::PlatformProxy;
-use rog_dbus::zbus_xgm_led::XgmLedProxy;
+use rog_dbus::{AsusArmouryProxy, XgmLedProxy};
 use rog_platform::asus_armoury::FirmwareAttribute;
 use slint::{ComponentHandle, SharedString, Weak};
 
 use super::show_toast;
-use crate::zbus_proxies::find_iface_async;
 use crate::{GPUPageData, MainWindow};
 
 /// A selectable GPU mode, independent of which sysfs attributes back it.
@@ -42,7 +39,7 @@ struct GpuCaps {
 impl GpuCaps {
     /// Collect the dgpu_disable / gpu_mux_mode proxies from asusd.
     async fn discover() -> Result<Self, Box<dyn std::error::Error>> {
-        let attrs = find_iface_async::<AsusArmouryProxy>("xyz.ljones.AsusArmoury").await?;
+        let attrs = rog_dbus::find_armoury_proxies().await?;
         let mut caps = GpuCaps {
             dgpu: None,
             mux: None,
@@ -240,8 +237,7 @@ pub fn setup_gpu_page(ui: &MainWindow) {
 
         // --- APU mem ---
         let apu_mem_proxy: Option<AsusArmouryProxy<'static>> = async {
-            let Ok(attrs) = find_iface_async::<AsusArmouryProxy>("xyz.ljones.AsusArmoury").await
-            else {
+            let Ok(attrs) = rog_dbus::find_armoury_proxies().await else {
                 error!("setup_gpu: failed to find AsusArmoury proxies for apu_mem");
                 return None;
             };
@@ -292,7 +288,7 @@ pub fn setup_gpu_page(ui: &MainWindow) {
 
         // --- XG Mobile LED ---
         let xgm_results: Option<(XgmLedProxy<'static>, bool)> = async {
-            let Ok(mut proxies) = find_iface_async::<XgmLedProxy>("xyz.ljones.XgmLed").await else {
+            let Ok(mut proxies) = rog_dbus::find_xgm_led_proxies().await else {
                 info!("setup_gpu: no XG Mobile LED interface");
                 return None;
             };
@@ -351,16 +347,10 @@ pub fn setup_gpu_page(ui: &MainWindow) {
         }
 
         // --- Disable nvidia-powerd on battery ---
-        let platform_proxy = match rog_dbus::system_connection().await {
-            Ok(conn) => match PlatformProxy::builder(conn).build().await {
-                Ok(p) => p,
-                Err(e) => {
-                    error!("setup_gpu: failed to create PlatformProxy: {e:?}");
-                    return;
-                }
-            },
+        let platform_proxy = match rog_dbus::platform_proxy().await {
+            Ok(p) => p,
             Err(e) => {
-                error!("setup_gpu: failed to connect to system bus: {e:?}");
+                error!("setup_gpu: failed to create PlatformProxy: {e:?}");
                 return;
             }
         };

--- a/rog-control-center/src/ui/setup_slash.rs
+++ b/rog-control-center/src/ui/setup_slash.rs
@@ -1,9 +1,7 @@
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-use log::{error, info};
-use rog_dbus::find_iface_async;
-use rog_dbus::zbus_slash::SlashProxy;
+use log::{error, info, warn};
 use rog_slash::SlashMode;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
@@ -38,7 +36,7 @@ fn slash_mode_from_index(index: i32) -> SlashMode {
 pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
     let handle = ui.as_weak();
     tokio::spawn(async move {
-        let Ok(slashes) = find_iface_async::<SlashProxy>("xyz.ljones.Slash").await else {
+        let Ok(slashes) = rog_dbus::find_slash_proxies().await else {
             info!("This device appears to have no slash interface");
             return;
         };
@@ -62,15 +60,15 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
             match slash.mode().await {
                 Ok(raw) => match SlashMode::try_from(raw) {
                     Ok(m) => mode = Some(m),
-                    Err(e) => log::warn!("slash mode at startup: unknown byte 0x{raw:02x}: {e}"),
+                    Err(e) => warn!("slash mode at startup: unknown byte 0x{raw:02x}: {e}"),
                 },
                 Err(e) => {
-                    log::warn!("slash mode unreadable at startup: {e}; retrying once");
+                    warn!("slash mode unreadable at startup: {e}; retrying once");
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     if let Ok(raw) = slash.mode().await {
                         match SlashMode::try_from(raw) {
                             Ok(m) => mode = Some(m),
-                            Err(e) => log::warn!(
+                            Err(e) => warn!(
                                 "slash mode at startup (retry): unknown byte 0x{raw:02x}: {e}"
                             ),
                         }
@@ -79,7 +77,7 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
             }
             if let Some(m) = mode {
                 let idx = slash_mode_to_index(m);
-                log::info!("slash mode at startup: {:?} (index {})", m, idx);
+                info!("slash mode at startup: {:?} (index {})", m, idx);
                 let choices = slash_modes();
                 handle
                     .upgrade_in_event_loop(move |handle| {
@@ -89,7 +87,7 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                     })
                     .ok();
             } else {
-                log::error!("slash mode unreadable after retries; UI will show Static");
+                error!("slash mode unreadable after retries; UI will show Static");
             }
 
             handle
@@ -136,7 +134,7 @@ pub fn setup_slash_page(ui: &MainWindow, _states: Arc<Mutex<Config>>) {
                                             })
                                             .ok();
                                     }
-                                    Err(e) => log::warn!(
+                                    Err(e) => warn!(
                                         "setup_slash: received unknown slash mode 0x{raw:02x}: {e}"
                                     ),
                                 }

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -25,16 +25,6 @@ pub fn setup_system_page(
     _config: Arc<Mutex<Config>>,
     app_state: Arc<Mutex<AppState>>,
 ) {
-    let conn = zbus::blocking::Connection::system()
-        .map_err(|e| error!("DBus system connection failed: {e:?}"))
-        .unwrap();
-    let platform = PlatformProxyBlocking::builder(&conn)
-        .build()
-        .map_err(|e| error!("PlatformProxy failed: {e:?}"))
-        .unwrap();
-    // let armoury_attrs =
-    // find_iface::<AsusArmouryProxyBlocking>("xyz.ljones.AsusArmoury").unwrap();
-
     // Null everything before the setup step
     debug!("Defaulting system page values");
     ui.global::<SystemPageData>()
@@ -87,9 +77,24 @@ pub fn setup_system_page(
         .set_dgpu_name(dgpu_model.into());
     ui.global::<SystemPageData>().set_has_igpu(has_igpu);
 
-    if let Ok(sys_props) = platform
-        .supported_properties()
-        .map_err(|e| log::error!("Failed to get supported properties: {}", e))
+    let platform = match rog_dbus::system_connection_blocking() {
+        Ok(c) => match PlatformProxyBlocking::builder(c).build() {
+            Ok(p) => Some(p),
+            Err(e) => {
+                error!("PlatformProxy failed: {e:?}");
+                None
+            }
+        },
+        Err(e) => {
+            error!("DBus system connection failed: {e:?}");
+            None
+        }
+    };
+
+    if let Some(platform) = platform
+        && let Ok(sys_props) = platform
+            .supported_properties()
+            .map_err(|e| log::error!("Failed to get supported properties: {}", e))
     {
         log::debug!("Available system properties: {:?}", sys_props);
         if sys_props.contains(&Properties::ChargeControlEndThreshold) {
@@ -417,21 +422,21 @@ pub fn setup_system_page_callbacks(ui: &MainWindow, _states: Arc<Mutex<Config>>)
 
     tokio::spawn(async move {
         // Create the connections/proxies here to prevent future delays in process
-        let conn = match zbus::Connection::system().await {
+        let conn = match rog_dbus::system_connection().await {
             Ok(c) => c,
             Err(e) => {
                 log::error!("Failed to connect to system bus: {e}");
                 return;
             }
         };
-        let platform = match PlatformProxy::builder(&conn).build().await {
+        let platform = match PlatformProxy::builder(conn).build().await {
             Ok(p) => p,
             Err(e) => {
                 log::error!("Failed to create platform proxy: {e}");
                 return;
             }
         };
-        let backlight = match BacklightProxy::builder(&conn).build().await {
+        let backlight = match BacklightProxy::builder(conn).build().await {
             Ok(b) => b,
             Err(e) => {
                 log::error!("Failed to create backlight proxy: {e}");

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -87,7 +87,7 @@ pub fn setup_system_page(
             .supported_properties()
             .map_err(|e| error!("Failed to get supported properties: {}", e))
     {
-        log::debug!("Available system properties: {:?}", sys_props);
+        debug!("Available system properties: {:?}", sys_props);
         if sys_props.contains(&Properties::ChargeControlEndThreshold) {
             ui.global::<SystemPageData>()
                 .set_charge_control_end_threshold(60.0);

--- a/rog-control-center/src/ui/setup_system.rs
+++ b/rog-control-center/src/ui/setup_system.rs
@@ -2,16 +2,13 @@ use std::sync::{Arc, Mutex};
 
 use concat_idents::concat_idents;
 use log::{debug, error};
-use rog_dbus::asus_armoury::AsusArmouryProxy;
-use rog_dbus::zbus_backlight::BacklightProxy;
-use rog_dbus::zbus_platform::{PlatformProxy, PlatformProxyBlocking};
 use rog_platform::asus_armoury::FirmwareAttribute;
 use rog_platform::platform::Properties;
 use slint::{ComponentHandle, Model, ModelRc, SharedString, VecModel};
 
 use super::show_toast;
 use crate::config::Config;
-use crate::zbus_proxies::{AppState, find_iface_async};
+use crate::zbus_proxies::AppState;
 use crate::{AttrMinMax, MainWindow, SystemPageData, set_ui_callbacks};
 
 const MINMAX: AttrMinMax = AttrMinMax {
@@ -77,16 +74,10 @@ pub fn setup_system_page(
         .set_dgpu_name(dgpu_model.into());
     ui.global::<SystemPageData>().set_has_igpu(has_igpu);
 
-    let platform = match rog_dbus::system_connection_blocking() {
-        Ok(c) => match PlatformProxyBlocking::builder(c).build() {
-            Ok(p) => Some(p),
-            Err(e) => {
-                error!("PlatformProxy failed: {e:?}");
-                None
-            }
-        },
+    let platform = match rog_dbus::platform_proxy_blocking() {
+        Ok(p) => Some(p),
         Err(e) => {
-            error!("DBus system connection failed: {e:?}");
+            error!("PlatformProxy failed: {e:?}");
             None
         }
     };
@@ -94,7 +85,7 @@ pub fn setup_system_page(
     if let Some(platform) = platform
         && let Ok(sys_props) = platform
             .supported_properties()
-            .map_err(|e| log::error!("Failed to get supported properties: {}", e))
+            .map_err(|e| error!("Failed to get supported properties: {}", e))
     {
         log::debug!("Available system properties: {:?}", sys_props);
         if sys_props.contains(&Properties::ChargeControlEndThreshold) {
@@ -222,21 +213,21 @@ macro_rules! init_minmax_property {
             let min = match proxy_copy.min_value().await {
                 Ok(m) => m,
                 Err(e) => {
-                    log::error!("Failed to read min value for property {}: {}", stringify!($property), e);
+                    error!("Failed to read min value for property {}: {}", stringify!($property), e);
                     return;
                 }
             };
             let max = match proxy_copy.max_value().await {
                 Ok(m) => m,
                 Err(e) => {
-                    log::error!("Failed to read max value for property {}: {}", stringify!($property), e);
+                    error!("Failed to read max value for property {}: {}", stringify!($property), e);
                     return;
                 }
             };
             let current = match proxy_copy.current_value().await {
                 Ok(c) => c as f32,
                 Err(e) => {
-                    log::error!("Failed to read current value for property {}: {}", stringify!($property), e);
+                    error!("Failed to read current value for property {}: {}", stringify!($property), e);
                     return;
                 }
             };
@@ -367,21 +358,21 @@ macro_rules! setup_minmax_external {
                     let min = match proxy_copy.min_value().await {
                         Ok(m) => m,
                         Err(e) => {
-                            log::error!("Failed to get min value on profile change: {e}");
+                            error!("Failed to get min value on profile change: {e}");
                             continue;
                         }
                     };
                     let max = match proxy_copy.max_value().await {
                         Ok(m) => m,
                         Err(e) => {
-                            log::error!("Failed to get max value on profile change: {e}");
+                            error!("Failed to get max value on profile change: {e}");
                             continue;
                         }
                     };
                     let current = match proxy_copy.current_value().await {
                         Ok(c) => c as f32,
                         Err(e) => {
-                            log::error!("Failed to get current value on profile change: {e}");
+                            error!("Failed to get current value on profile change: {e}");
                             continue;
                         }
                     };
@@ -422,24 +413,17 @@ pub fn setup_system_page_callbacks(ui: &MainWindow, _states: Arc<Mutex<Config>>)
 
     tokio::spawn(async move {
         // Create the connections/proxies here to prevent future delays in process
-        let conn = match rog_dbus::system_connection().await {
-            Ok(c) => c,
-            Err(e) => {
-                log::error!("Failed to connect to system bus: {e}");
-                return;
-            }
-        };
-        let platform = match PlatformProxy::builder(conn).build().await {
+        let platform = match rog_dbus::platform_proxy().await {
             Ok(p) => p,
             Err(e) => {
-                log::error!("Failed to create platform proxy: {e}");
+                error!("Failed to create platform proxy: {e}");
                 return;
             }
         };
-        let backlight = match BacklightProxy::builder(conn).build().await {
+        let backlight = match rog_dbus::backlight_proxy().await {
             Ok(b) => b,
             Err(e) => {
-                log::error!("Failed to create backlight proxy: {e}");
+                error!("Failed to create backlight proxy: {e}");
                 return;
             }
         };
@@ -700,7 +684,7 @@ pub fn setup_system_page_callbacks(ui: &MainWindow, _states: Arc<Mutex<Config>>)
             .ok();
 
         let armoury_attrs;
-        if let Ok(attrs) = find_iface_async::<AsusArmouryProxy>("xyz.ljones.AsusArmoury").await {
+        if let Ok(attrs) = rog_dbus::find_armoury_proxies().await {
             debug!("Found AsusArmoury interfaces");
             armoury_attrs = attrs;
             handle
@@ -718,131 +702,129 @@ pub fn setup_system_page_callbacks(ui: &MainWindow, _states: Arc<Mutex<Config>>)
         }
 
         for attr in armoury_attrs {
-            if let Ok(value) = attr.current_value().await {
-                if let Ok(name) = attr.name().await {
-                    debug!("Setting up {} = {value}", <&str>::from(name));
-                    let platform = platform.clone();
-                    handle
-                        .upgrade_in_event_loop(move |handle| match name {
-                            FirmwareAttribute::ApuMem => {}
-                            FirmwareAttribute::CoresPerformance => {}
-                            FirmwareAttribute::CoresEfficiency => {}
-                            FirmwareAttribute::PptPl1Spl => {
-                                init_minmax_property!(ppt_pl1_spl, handle, attr);
-                                setup_callback!(ppt_pl1_spl, handle, attr);
-                                setup_callback_restore_default!(ppt_pl1_spl, handle, attr);
-                                setup_minmax_external!(ppt_pl1_spl, handle, attr, platform);
-                            }
-                            FirmwareAttribute::PptPl2Sppt => {
-                                init_minmax_property!(ppt_pl2_sppt, handle, attr);
-                                setup_callback!(ppt_pl2_sppt, handle, attr);
-                                setup_callback_restore_default!(ppt_pl2_sppt, handle, attr);
-                                setup_minmax_external!(ppt_pl2_sppt, handle, attr, platform);
-                            }
-                            FirmwareAttribute::PptPl3Fppt => {
-                                init_minmax_property!(ppt_pl3_fppt, handle, attr);
-                                setup_callback!(ppt_pl3_fppt, handle, attr);
-                                setup_callback_restore_default!(ppt_pl3_fppt, handle, attr);
-                                setup_minmax_external!(ppt_pl3_fppt, handle, attr, platform);
-                            }
-                            FirmwareAttribute::PptFppt => {
-                                init_minmax_property!(ppt_fppt, handle, attr);
-                                setup_callback!(ppt_fppt, handle, attr);
-                                setup_callback_restore_default!(ppt_fppt, handle, attr);
-                                setup_minmax_external!(ppt_fppt, handle, attr, platform);
-                            }
-                            FirmwareAttribute::PptApuSppt => {
-                                init_minmax_property!(ppt_apu_sppt, handle, attr);
-                                setup_callback!(ppt_apu_sppt, handle, attr);
-                                setup_callback_restore_default!(ppt_apu_sppt, handle, attr);
-                                setup_minmax_external!(ppt_apu_sppt, handle, attr, platform);
-                            }
-                            FirmwareAttribute::PptPlatformSppt => {
-                                init_minmax_property!(ppt_platform_sppt, handle, attr);
-                                setup_callback!(ppt_platform_sppt, handle, attr);
-                                setup_callback_restore_default!(ppt_platform_sppt, handle, attr);
-                                setup_minmax_external!(ppt_platform_sppt, handle, attr, platform);
-                            }
-                            FirmwareAttribute::NvDynamicBoost => {
-                                init_minmax_property!(nv_dynamic_boost, handle, attr);
-                                setup_callback!(nv_dynamic_boost, handle, attr);
-                                setup_callback_restore_default!(nv_dynamic_boost, handle, attr);
-                                setup_minmax_external!(nv_dynamic_boost, handle, attr, platform);
-                            }
-                            FirmwareAttribute::NvTempTarget => {
-                                init_minmax_property!(nv_temp_target, handle, attr);
-                                setup_callback!(nv_temp_target, handle, attr);
-                                setup_callback_restore_default!(nv_temp_target, handle, attr);
-                                setup_minmax_external!(nv_temp_target, handle, attr, platform);
-                            }
-                            FirmwareAttribute::DgpuBaseTgp => {}
-                            FirmwareAttribute::DgpuTgp => {
-                                init_minmax_property!(nv_tgp, handle, attr);
-                                setup_callback!(nv_tgp, handle, attr);
-                                setup_callback_restore_default!(nv_tgp, handle, attr);
-                                setup_minmax_external!(nv_tgp, handle, attr, platform);
-                            }
-                            FirmwareAttribute::ChargeMode => {}
-                            FirmwareAttribute::BootSound => {
-                                init_property!(boot_sound, handle, value);
-                                setup_callback!(boot_sound, handle, attr);
-                                setup_external!(boot_sound, handle, attr, value)
-                            }
-                            FirmwareAttribute::ScreenAutoBrightness => {
-                                init_property!(screen_auto_brightness, handle, value);
-                                setup_callback!(screen_auto_brightness, handle, attr);
-                                setup_external!(screen_auto_brightness, handle, attr, value)
-                            }
-                            FirmwareAttribute::McuPowersave => {
-                                init_property!(mcu_powersave, handle, value);
-                                setup_callback!(mcu_powersave, handle, attr);
-                                setup_external!(mcu_powersave, handle, attr, value)
-                            }
-                            FirmwareAttribute::PanelOverdrive => {
-                                init_property!(panel_overdrive, handle, value);
-                                setup_callback!(panel_overdrive, handle, attr);
-                                setup_external!(panel_overdrive, handle, attr, value)
-                            }
-                            FirmwareAttribute::PanelHdMode => {}
-                            FirmwareAttribute::EgpuConnected => {}
-                            FirmwareAttribute::EgpuEnable => {}
-                            FirmwareAttribute::DgpuDisable => {}
-                            FirmwareAttribute::GpuMuxMode => {}
-                            FirmwareAttribute::MiniLedMode => {
-                                init_property!(mini_led_mode, handle, value);
-                                setup_callback!(mini_led_mode, handle, attr);
-                                setup_external!(mini_led_mode, handle, attr, value);
+            if let Ok(value) = attr.current_value().await
+                && let Ok(name) = attr.name().await
+            {
+                debug!("Setting up {} = {value}", <&str>::from(name));
+                let platform = platform.clone();
+                handle
+                    .upgrade_in_event_loop(move |handle| match name {
+                        FirmwareAttribute::ApuMem => {}
+                        FirmwareAttribute::CoresPerformance => {}
+                        FirmwareAttribute::CoresEfficiency => {}
+                        FirmwareAttribute::PptPl1Spl => {
+                            init_minmax_property!(ppt_pl1_spl, handle, attr);
+                            setup_callback!(ppt_pl1_spl, handle, attr);
+                            setup_callback_restore_default!(ppt_pl1_spl, handle, attr);
+                            setup_minmax_external!(ppt_pl1_spl, handle, attr, platform);
+                        }
+                        FirmwareAttribute::PptPl2Sppt => {
+                            init_minmax_property!(ppt_pl2_sppt, handle, attr);
+                            setup_callback!(ppt_pl2_sppt, handle, attr);
+                            setup_callback_restore_default!(ppt_pl2_sppt, handle, attr);
+                            setup_minmax_external!(ppt_pl2_sppt, handle, attr, platform);
+                        }
+                        FirmwareAttribute::PptPl3Fppt => {
+                            init_minmax_property!(ppt_pl3_fppt, handle, attr);
+                            setup_callback!(ppt_pl3_fppt, handle, attr);
+                            setup_callback_restore_default!(ppt_pl3_fppt, handle, attr);
+                            setup_minmax_external!(ppt_pl3_fppt, handle, attr, platform);
+                        }
+                        FirmwareAttribute::PptFppt => {
+                            init_minmax_property!(ppt_fppt, handle, attr);
+                            setup_callback!(ppt_fppt, handle, attr);
+                            setup_callback_restore_default!(ppt_fppt, handle, attr);
+                            setup_minmax_external!(ppt_fppt, handle, attr, platform);
+                        }
+                        FirmwareAttribute::PptApuSppt => {
+                            init_minmax_property!(ppt_apu_sppt, handle, attr);
+                            setup_callback!(ppt_apu_sppt, handle, attr);
+                            setup_callback_restore_default!(ppt_apu_sppt, handle, attr);
+                            setup_minmax_external!(ppt_apu_sppt, handle, attr, platform);
+                        }
+                        FirmwareAttribute::PptPlatformSppt => {
+                            init_minmax_property!(ppt_platform_sppt, handle, attr);
+                            setup_callback!(ppt_platform_sppt, handle, attr);
+                            setup_callback_restore_default!(ppt_platform_sppt, handle, attr);
+                            setup_minmax_external!(ppt_platform_sppt, handle, attr, platform);
+                        }
+                        FirmwareAttribute::NvDynamicBoost => {
+                            init_minmax_property!(nv_dynamic_boost, handle, attr);
+                            setup_callback!(nv_dynamic_boost, handle, attr);
+                            setup_callback_restore_default!(nv_dynamic_boost, handle, attr);
+                            setup_minmax_external!(nv_dynamic_boost, handle, attr, platform);
+                        }
+                        FirmwareAttribute::NvTempTarget => {
+                            init_minmax_property!(nv_temp_target, handle, attr);
+                            setup_callback!(nv_temp_target, handle, attr);
+                            setup_callback_restore_default!(nv_temp_target, handle, attr);
+                            setup_minmax_external!(nv_temp_target, handle, attr, platform);
+                        }
+                        FirmwareAttribute::DgpuBaseTgp => {}
+                        FirmwareAttribute::DgpuTgp => {
+                            init_minmax_property!(nv_tgp, handle, attr);
+                            setup_callback!(nv_tgp, handle, attr);
+                            setup_callback_restore_default!(nv_tgp, handle, attr);
+                            setup_minmax_external!(nv_tgp, handle, attr, platform);
+                        }
+                        FirmwareAttribute::ChargeMode => {}
+                        FirmwareAttribute::BootSound => {
+                            init_property!(boot_sound, handle, value);
+                            setup_callback!(boot_sound, handle, attr);
+                            setup_external!(boot_sound, handle, attr, value)
+                        }
+                        FirmwareAttribute::ScreenAutoBrightness => {
+                            init_property!(screen_auto_brightness, handle, value);
+                            setup_callback!(screen_auto_brightness, handle, attr);
+                            setup_external!(screen_auto_brightness, handle, attr, value)
+                        }
+                        FirmwareAttribute::McuPowersave => {
+                            init_property!(mcu_powersave, handle, value);
+                            setup_callback!(mcu_powersave, handle, attr);
+                            setup_external!(mcu_powersave, handle, attr, value)
+                        }
+                        FirmwareAttribute::PanelOverdrive => {
+                            init_property!(panel_overdrive, handle, value);
+                            setup_callback!(panel_overdrive, handle, attr);
+                            setup_external!(panel_overdrive, handle, attr, value)
+                        }
+                        FirmwareAttribute::PanelHdMode => {}
+                        FirmwareAttribute::EgpuConnected => {}
+                        FirmwareAttribute::EgpuEnable => {}
+                        FirmwareAttribute::DgpuDisable => {}
+                        FirmwareAttribute::GpuMuxMode => {}
+                        FirmwareAttribute::MiniLedMode => {
+                            init_property!(mini_led_mode, handle, value);
+                            setup_callback!(mini_led_mode, handle, attr);
+                            setup_external!(mini_led_mode, handle, attr, value);
 
-                                // possible_values count tells us how many dimming
-                                // modes the device has: 2 (MODE1) or 3 (MODE2).
-                                let handle_copy = handle.as_weak();
-                                let proxy_copy = attr.clone();
-                                tokio::spawn(async move {
-                                    let count = proxy_copy
-                                        .possible_values()
-                                        .await
-                                        .map(|v| v.len())
-                                        .unwrap_or(2);
-                                    handle_copy
-                                        .upgrade_in_event_loop(move |handle| {
-                                            let data = handle.global::<SystemPageData>();
-                                            let choices = if count >= 3 {
-                                                data.get_mini_led_choices_modes()
-                                            } else {
-                                                data.get_mini_led_choices_onoff()
-                                            };
-                                            data.set_mini_led_mode_choices(choices);
-                                        })
-                                        .ok();
-                                });
-                            }
-                            FirmwareAttribute::PendingReboot => {}
-                            FirmwareAttribute::None => {}
-                        })
-                        .ok();
-                } else {
-                    error!("Attribute with no name, skipping");
-                }
+                            // possible_values count tells us how many dimming
+                            // modes the device has: 2 (MODE1) or 3 (MODE2).
+                            let handle_copy = handle.as_weak();
+                            let proxy_copy = attr.clone();
+                            tokio::spawn(async move {
+                                let count = proxy_copy
+                                    .possible_values()
+                                    .await
+                                    .map(|v| v.len())
+                                    .unwrap_or(2);
+                                handle_copy
+                                    .upgrade_in_event_loop(move |handle| {
+                                        let data = handle.global::<SystemPageData>();
+                                        let choices = if count >= 3 {
+                                            data.get_mini_led_choices_modes()
+                                        } else {
+                                            data.get_mini_led_choices_onoff()
+                                        };
+                                        data.set_mini_led_mode_choices(choices);
+                                    })
+                                    .ok();
+                            });
+                        }
+                        FirmwareAttribute::PendingReboot => {}
+                        FirmwareAttribute::None => {}
+                    })
+                    .ok();
             }
         }
         handle

--- a/rog-control-center/src/zbus_proxies.rs
+++ b/rog-control-center/src/zbus_proxies.rs
@@ -67,7 +67,3 @@ pub trait ROGCCZbus {
     #[zbus(property)]
     fn set_state(&self, state: AppState) -> zbus::Result<()>;
 }
-
-pub use rog_dbus::find_iface_async;
-pub use rog_dbus::find_iface_blocking as find_iface;
-pub use rog_dbus::find_iface_blocking;

--- a/rog-control-center/src/zbus_proxies.rs
+++ b/rog-control-center/src/zbus_proxies.rs
@@ -1,8 +1,5 @@
-use log::info;
 use std::sync::{Arc, Mutex};
 
-use zbus::blocking::proxy::ProxyImpl;
-use zbus::blocking::{Connection, fdo};
 use zbus::zvariant::{OwnedValue, Type, Value};
 use zbus::{interface, proxy};
 
@@ -71,79 +68,6 @@ pub trait ROGCCZbus {
     fn set_state(&self, state: AppState) -> zbus::Result<()>;
 }
 
-pub fn find_iface<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::error::Error>>
-where
-    T: ProxyImpl<'static> + From<zbus::Proxy<'static>>,
-{
-    let conn = Connection::system()?;
-    let f = fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/")?;
-    let interfaces = f.get_managed_objects()?;
-    let mut paths = Vec::new();
-    for v in interfaces.iter() {
-        // let o: Vec<zbus::names::OwnedInterfaceName> = v.1.keys().map(|e|
-        // e.to_owned()).collect(); println!("{}, {:?}", v.0, o);
-        for k in v.1.keys() {
-            if k.as_str() == iface_name {
-                // println!("Found {iface_name} device at {}, {}", v.0, k);
-                paths.push(v.0.clone());
-            }
-        }
-    }
-    if paths.len() > 1 {
-        info!("Multiple asusd interfaces devices found");
-    }
-    if !paths.is_empty() {
-        let mut ctrl = Vec::new();
-        paths.sort_by(|a, b| a.cmp(b));
-        for path in paths {
-            ctrl.push(
-                T::builder(&conn)
-                    .path(path.clone())?
-                    .destination("xyz.ljones.Asusd")?
-                    .build()?,
-            );
-        }
-        return Ok(ctrl);
-    }
-
-    Err("No Aura interface".into())
-}
-
-pub async fn find_iface_async<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::error::Error>>
-where
-    T: zbus::proxy::ProxyImpl<'static> + From<zbus::Proxy<'static>>,
-{
-    let conn = zbus::Connection::system().await?;
-    let f = zbus::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/").await?;
-    let interfaces = f.get_managed_objects().await?;
-    let mut paths = Vec::new();
-    for v in interfaces.iter() {
-        // let o: Vec<zbus::names::OwnedInterfaceName> = v.1.keys().map(|e|
-        // e.to_owned()).collect(); println!("{}, {:?}", v.0, o);
-        for k in v.1.keys() {
-            if k.as_str() == iface_name {
-                // println!("Found {iface_name} device at {}, {}", v.0, k);
-                paths.push(v.0.clone());
-            }
-        }
-    }
-    if paths.len() > 1 {
-        info!("Multiple asusd interfaces devices found");
-    }
-    if !paths.is_empty() {
-        let mut ctrl = Vec::new();
-        paths.sort_by(|a, b| a.cmp(b));
-        for path in paths {
-            ctrl.push(
-                T::builder(&conn)
-                    .path(path.clone())?
-                    .destination("xyz.ljones.Asusd")?
-                    .build()
-                    .await?,
-            );
-        }
-        return Ok(ctrl);
-    }
-
-    Err("No interface".into())
-}
+pub use rog_dbus::find_iface_async;
+pub use rog_dbus::find_iface_blocking as find_iface;
+pub use rog_dbus::find_iface_blocking;

--- a/rog-dbus/Cargo.toml
+++ b/rog-dbus/Cargo.toml
@@ -17,6 +17,6 @@ rog_scsi = { path = "../rog-scsi", features = ["dbus"] }
 rog_aura = { path = "../rog-aura" }
 rog_profiles = { path = "../rog-profiles" }
 rog_platform = { path = "../rog-platform" }
-zbus.workspace = true
 log.workspace = true
-
+tokio.workspace = true
+zbus.workspace = true

--- a/rog-dbus/src/lib.rs
+++ b/rog-dbus/src/lib.rs
@@ -1,4 +1,6 @@
 pub use asusd::{DBUS_IFACE, DBUS_NAME, DBUS_PATH};
+use std::sync::OnceLock;
+use tokio::sync::OnceCell;
 use zbus::proxy::ProxyImpl;
 
 pub mod asus_armoury;
@@ -13,13 +15,58 @@ pub mod zbus_xgm_led;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn list_iface_blocking() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+static BLOCKING_CONN: OnceLock<zbus::blocking::Connection> = OnceLock::new();
+static ASYNC_CONN: OnceCell<zbus::Connection> = OnceCell::const_new();
+
+/// Return a shared process-wide blocking D-Bus system connection.
+///
+/// Note: The initial `get()` plus `get_or_init()` may briefly create two connections
+/// under a race condition, with the losing connection dropped intentionally because
+/// `OnceLock::get_or_try_init` is unavailable.
+pub fn system_connection_blocking() -> zbus::Result<&'static zbus::blocking::Connection> {
+    if let Some(conn) = BLOCKING_CONN.get() {
+        return Ok(conn);
+    }
     let conn = zbus::blocking::Connection::system()?;
-    let f = zbus::blocking::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/")?;
+    Ok(BLOCKING_CONN.get_or_init(|| conn))
+}
+
+/// Return a shared process-wide async D-Bus system connection.
+pub async fn system_connection() -> zbus::Result<&'static zbus::Connection> {
+    ASYNC_CONN
+        .get_or_try_init(|| async { zbus::Connection::system().await })
+        .await
+}
+
+/// Compare D-Bus object paths, sorting trailing numeric segments by value (e.g. `/.../0`, `/.../2`, `/.../10`)
+/// with standard byte-order comparison as the fallback.
+fn cmp_object_paths(
+    a: &zbus::zvariant::OwnedObjectPath,
+    b: &zbus::zvariant::OwnedObjectPath,
+) -> std::cmp::Ordering {
+    let a_str = a.as_str();
+    let b_str = b.as_str();
+    let (prefix_a, seg_a) = a_str.rsplit_once('/').unwrap_or(("", a_str));
+    let (prefix_b, seg_b) = b_str.rsplit_once('/').unwrap_or(("", b_str));
+    match prefix_a.cmp(prefix_b) {
+        std::cmp::Ordering::Equal => {
+            if let (Ok(num_a), Ok(num_b)) = (seg_a.parse::<u64>(), seg_b.parse::<u64>()) {
+                num_a.cmp(&num_b)
+            } else {
+                seg_a.cmp(seg_b)
+            }
+        }
+        other => other,
+    }
+}
+
+pub fn list_iface_blocking() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let conn = system_connection_blocking()?;
+    let f = zbus::blocking::fdo::ObjectManagerProxy::new(conn, "xyz.ljones.Asusd", "/")?;
     let interfaces = f.get_managed_objects()?;
     let mut ifaces = Vec::new();
-    for v in interfaces.iter() {
-        for k in v.1.keys() {
+    for ifaces_map in interfaces.values() {
+        for k in ifaces_map.keys() {
             ifaces.push(k.to_string());
         }
     }
@@ -32,30 +79,35 @@ pub async fn find_iface_async<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std
 where
     T: ProxyImpl<'static> + From<zbus::Proxy<'static>>,
 {
-    let conn = zbus::Connection::system().await?;
-    let f = zbus::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/").await?;
+    let conn = system_connection().await?;
+    find_iface_async_with_conn(conn, iface_name).await
+}
+
+pub async fn find_iface_async_with_conn<T>(
+    conn: &zbus::Connection,
+    iface_name: &str,
+) -> Result<Vec<T>, Box<dyn std::error::Error>>
+where
+    T: ProxyImpl<'static> + From<zbus::Proxy<'static>>,
+{
+    let f = zbus::fdo::ObjectManagerProxy::new(conn, "xyz.ljones.Asusd", "/").await?;
     let interfaces = f.get_managed_objects().await?;
     let mut paths = Vec::new();
-    for v in interfaces.iter() {
-        // let o: Vec<zbus::names::OwnedInterfaceName> = v.1.keys().map(|e|
-        // e.to_owned()).collect(); println!("{}, {:?}", v.0, o);
-        for k in v.1.keys() {
-            if k.as_str() == iface_name {
-                // println!("Found {iface_name} device at {}, {}", v.0, k);
-                paths.push(v.0.clone());
-            }
+    for (path, ifaces) in &interfaces {
+        if ifaces.contains_key(iface_name) {
+            paths.push(path.clone());
         }
     }
     if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found");
+        log::warn!("Multiple asusd interfaces devices found for {iface_name}");
     }
     if !paths.is_empty() {
         let mut ctrl = Vec::new();
-        paths.sort_by(|a, b| a.cmp(b));
+        paths.sort_by(cmp_object_paths);
         for path in paths {
             ctrl.push(
-                T::builder(&conn)
-                    .path(path.clone())?
+                T::builder(conn)
+                    .path(path)?
                     .destination("xyz.ljones.Asusd")?
                     .build()
                     .await?,
@@ -71,27 +123,35 @@ pub fn find_iface_blocking<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::e
 where
     T: zbus::blocking::proxy::ProxyImpl<'static> + From<zbus::Proxy<'static>>,
 {
-    let conn = zbus::blocking::Connection::system()?;
-    let f = zbus::blocking::fdo::ObjectManagerProxy::new(&conn, "xyz.ljones.Asusd", "/")?;
+    let conn = system_connection_blocking()?;
+    find_iface_blocking_with_conn(conn, iface_name)
+}
+
+pub fn find_iface_blocking_with_conn<T>(
+    conn: &zbus::blocking::Connection,
+    iface_name: &str,
+) -> Result<Vec<T>, Box<dyn std::error::Error>>
+where
+    T: zbus::blocking::proxy::ProxyImpl<'static> + From<zbus::Proxy<'static>>,
+{
+    let f = zbus::blocking::fdo::ObjectManagerProxy::new(conn, "xyz.ljones.Asusd", "/")?;
     let interfaces = f.get_managed_objects()?;
     let mut paths = Vec::new();
-    for v in interfaces.iter() {
-        for k in v.1.keys() {
-            if k.as_str() == iface_name {
-                paths.push(v.0.clone());
-            }
+    for (path, ifaces) in &interfaces {
+        if ifaces.contains_key(iface_name) {
+            paths.push(path.clone());
         }
     }
     if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found");
+        log::warn!("Multiple asusd interfaces devices found for {iface_name}");
     }
     if !paths.is_empty() {
         let mut ctrl = Vec::new();
-        paths.sort_by(|a, b| a.cmp(b));
+        paths.sort_by(cmp_object_paths);
         for path in paths {
             ctrl.push(
-                T::builder(&conn)
-                    .path(path.clone())?
+                T::builder(conn)
+                    .path(path)?
                     .destination("xyz.ljones.Asusd")?
                     .build()?,
             );
@@ -100,4 +160,72 @@ where
     }
 
     Err(format!("Did not find {iface_name}").into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cmp_object_paths() {
+        use zbus::zvariant::OwnedObjectPath;
+
+        let path0: OwnedObjectPath = "/xyz/ljones/Aura/0".try_into().expect("valid object path");
+        let path2: OwnedObjectPath = "/xyz/ljones/Aura/2".try_into().expect("valid object path");
+        let path10: OwnedObjectPath = "/xyz/ljones/Aura/10".try_into().expect("valid object path");
+        let path_slash: OwnedObjectPath = "/xyz/ljones/Aura/slash"
+            .try_into()
+            .expect("valid object path");
+        let path_tuf: OwnedObjectPath = "/xyz/ljones/Aura/tuf"
+            .try_into()
+            .expect("valid object path");
+
+        let mut paths = vec![
+            path10.clone(),
+            path_tuf.clone(),
+            path0.clone(),
+            path_slash.clone(),
+            path2.clone(),
+        ];
+        paths.sort_by(cmp_object_paths);
+
+        assert_eq!(
+            paths,
+            vec![
+                path0, path2, path10, path_slash, path_tuf
+            ]
+        );
+    }
+
+    #[test]
+    fn test_system_connection_blocking_singleton() {
+        let conn1 = match system_connection_blocking() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "Skipping test_system_connection_blocking_singleton: system D-Bus unavailable: {e}"
+                );
+                return;
+            }
+        };
+        let conn2 = system_connection_blocking().expect("second call must succeed");
+        assert!(std::ptr::eq(conn1, conn2));
+    }
+
+    #[tokio::test]
+    async fn test_system_connection_async_singleton() {
+        let conn1 = match system_connection().await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "Skipping test_system_connection_async_singleton: system D-Bus unavailable: {e}"
+                );
+                return;
+            }
+        };
+        let conn2 = system_connection()
+            .await
+            .expect("second async call must succeed");
+        assert!(std::ptr::eq(conn1, conn2));
+    }
 }

--- a/rog-dbus/src/lib.rs
+++ b/rog-dbus/src/lib.rs
@@ -1,4 +1,5 @@
 pub use asusd::{DBUS_IFACE, DBUS_NAME, DBUS_PATH};
+use log::warn;
 use std::sync::OnceLock;
 use tokio::sync::OnceCell;
 use zbus::proxy::ProxyImpl;
@@ -12,6 +13,16 @@ pub mod zbus_fan_curves;
 pub mod zbus_platform;
 pub mod zbus_slash;
 pub mod zbus_xgm_led;
+
+pub use asus_armoury::{AsusArmouryProxy, AsusArmouryProxyBlocking};
+pub use scsi_aura::{ScsiAuraProxy, ScsiAuraProxyBlocking};
+pub use zbus_anime::{AnimeProxy, AnimeProxyBlocking};
+pub use zbus_aura::{AuraProxy, AuraProxyBlocking};
+pub use zbus_backlight::{BacklightProxy, BacklightProxyBlocking};
+pub use zbus_fan_curves::{FanCurvesProxy, FanCurvesProxyBlocking};
+pub use zbus_platform::{PlatformProxy, PlatformProxyBlocking};
+pub use zbus_slash::{SlashProxy, SlashProxyBlocking};
+pub use zbus_xgm_led::{XgmLedProxy, XgmLedProxyBlocking};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -92,31 +103,32 @@ where
 {
     let f = zbus::fdo::ObjectManagerProxy::new(conn, "xyz.ljones.Asusd", "/").await?;
     let interfaces = f.get_managed_objects().await?;
-    let mut paths = Vec::new();
-    for (path, ifaces) in &interfaces {
-        if ifaces.contains_key(iface_name) {
-            paths.push(path.clone());
-        }
-    }
-    if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found for {iface_name}");
-    }
-    if !paths.is_empty() {
-        let mut ctrl = Vec::new();
-        paths.sort_by(cmp_object_paths);
-        for path in paths {
-            ctrl.push(
-                T::builder(conn)
-                    .path(path)?
-                    .destination("xyz.ljones.Asusd")?
-                    .build()
-                    .await?,
-            );
-        }
-        return Ok(ctrl);
+    let mut paths: Vec<_> = interfaces
+        .iter()
+        .filter(|(_, ifaces)| ifaces.contains_key(iface_name))
+        .map(|(path, _)| path.clone())
+        .collect();
+
+    if paths.is_empty() {
+        return Err(format!("Did not find {iface_name}").into());
     }
 
-    Err(format!("Did not find {iface_name}").into())
+    if paths.len() > 1 {
+        warn!("Multiple asusd interfaces devices found for {iface_name}");
+    }
+
+    paths.sort_by(cmp_object_paths);
+    let mut ctrl = Vec::with_capacity(paths.len());
+    for path in paths {
+        ctrl.push(
+            T::builder(conn)
+                .path(path)?
+                .destination("xyz.ljones.Asusd")?
+                .build()
+                .await?,
+        );
+    }
+    Ok(ctrl)
 }
 
 pub fn find_iface_blocking<T>(iface_name: &str) -> Result<Vec<T>, Box<dyn std::error::Error>>
@@ -136,30 +148,136 @@ where
 {
     let f = zbus::blocking::fdo::ObjectManagerProxy::new(conn, "xyz.ljones.Asusd", "/")?;
     let interfaces = f.get_managed_objects()?;
-    let mut paths = Vec::new();
-    for (path, ifaces) in &interfaces {
-        if ifaces.contains_key(iface_name) {
-            paths.push(path.clone());
-        }
-    }
-    if paths.len() > 1 {
-        log::warn!("Multiple asusd interfaces devices found for {iface_name}");
-    }
-    if !paths.is_empty() {
-        let mut ctrl = Vec::new();
-        paths.sort_by(cmp_object_paths);
-        for path in paths {
-            ctrl.push(
-                T::builder(conn)
-                    .path(path)?
-                    .destination("xyz.ljones.Asusd")?
-                    .build()?,
-            );
-        }
-        return Ok(ctrl);
+    let mut paths: Vec<_> = interfaces
+        .iter()
+        .filter(|(_, ifaces)| ifaces.contains_key(iface_name))
+        .map(|(path, _)| path.clone())
+        .collect();
+
+    if paths.is_empty() {
+        return Err(format!("Did not find {iface_name}").into());
     }
 
-    Err(format!("Did not find {iface_name}").into())
+    if paths.len() > 1 {
+        warn!("Multiple asusd interfaces devices found for {iface_name}");
+    }
+
+    paths.sort_by(cmp_object_paths);
+    let mut ctrl = Vec::with_capacity(paths.len());
+    for path in paths {
+        ctrl.push(
+            T::builder(conn)
+                .path(path)?
+                .destination("xyz.ljones.Asusd")?
+                .build()?,
+        );
+    }
+    Ok(ctrl)
+}
+
+/// Obtain a PlatformProxy instance using the shared async system connection.
+pub async fn platform_proxy() -> zbus::Result<PlatformProxy<'static>> {
+    let conn = system_connection().await?;
+    PlatformProxy::new(conn).await
+}
+
+/// Obtain a PlatformProxyBlocking instance using the shared blocking system connection.
+pub fn platform_proxy_blocking() -> zbus::Result<PlatformProxyBlocking<'static>> {
+    let conn = system_connection_blocking()?;
+    PlatformProxyBlocking::new(conn)
+}
+
+/// Obtain a FanCurvesProxy instance using the shared async system connection.
+pub async fn fan_curves_proxy() -> zbus::Result<FanCurvesProxy<'static>> {
+    let conn = system_connection().await?;
+    FanCurvesProxy::new(conn).await
+}
+
+/// Obtain a FanCurvesProxyBlocking instance using the shared blocking system connection.
+pub fn fan_curves_proxy_blocking() -> zbus::Result<FanCurvesProxyBlocking<'static>> {
+    let conn = system_connection_blocking()?;
+    FanCurvesProxyBlocking::new(conn)
+}
+
+/// Obtain a BacklightProxy instance using the shared async system connection.
+pub async fn backlight_proxy() -> zbus::Result<BacklightProxy<'static>> {
+    let conn = system_connection().await?;
+    BacklightProxy::new(conn).await
+}
+
+/// Obtain a BacklightProxyBlocking instance using the shared blocking system connection.
+pub fn backlight_proxy_blocking() -> zbus::Result<BacklightProxyBlocking<'static>> {
+    let conn = system_connection_blocking()?;
+    BacklightProxyBlocking::new(conn)
+}
+
+/// Discover all AsusArmoury devices (async).
+pub async fn find_armoury_proxies()
+-> Result<Vec<AsusArmouryProxy<'static>>, Box<dyn std::error::Error>> {
+    find_iface_async("xyz.ljones.AsusArmoury").await
+}
+
+/// Discover all AsusArmoury devices (blocking).
+pub fn find_armoury_proxies_blocking()
+-> Result<Vec<AsusArmouryProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.AsusArmoury")
+}
+
+/// Discover all Aura devices (async).
+pub async fn find_aura_proxies() -> Result<Vec<AuraProxy<'static>>, Box<dyn std::error::Error>> {
+    find_iface_async("xyz.ljones.Aura").await
+}
+
+/// Discover all Aura devices (blocking).
+pub fn find_aura_proxies_blocking()
+-> Result<Vec<AuraProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.Aura")
+}
+
+/// Discover all Slash lighting devices (async).
+pub async fn find_slash_proxies() -> Result<Vec<SlashProxy<'static>>, Box<dyn std::error::Error>> {
+    find_iface_async("xyz.ljones.Slash").await
+}
+
+/// Discover all Slash lighting devices (blocking).
+pub fn find_slash_proxies_blocking()
+-> Result<Vec<SlashProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.Slash")
+}
+
+/// Discover all AniMe Matrix devices (async).
+pub async fn find_anime_proxies() -> Result<Vec<AnimeProxy<'static>>, Box<dyn std::error::Error>> {
+    find_iface_async("xyz.ljones.Anime").await
+}
+
+/// Discover all AniMe Matrix devices (blocking).
+pub fn find_anime_proxies_blocking()
+-> Result<Vec<AnimeProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.Anime")
+}
+
+/// Discover all XG Mobile LED devices (async).
+pub async fn find_xgm_led_proxies() -> Result<Vec<XgmLedProxy<'static>>, Box<dyn std::error::Error>>
+{
+    find_iface_async("xyz.ljones.XgmLed").await
+}
+
+/// Discover all XG Mobile LED devices (blocking).
+pub fn find_xgm_led_proxies_blocking()
+-> Result<Vec<XgmLedProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.XgmLed")
+}
+
+/// Discover all SCSI Aura devices (async).
+pub async fn find_scsi_aura_proxies()
+-> Result<Vec<ScsiAuraProxy<'static>>, Box<dyn std::error::Error>> {
+    find_iface_async("xyz.ljones.ScsiAura").await
+}
+
+/// Discover all SCSI Aura devices (blocking).
+pub fn find_scsi_aura_proxies_blocking()
+-> Result<Vec<ScsiAuraProxyBlocking<'static>>, Box<dyn std::error::Error>> {
+    find_iface_blocking("xyz.ljones.ScsiAura")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

This PR is based on #338 as a follow-up enhancement. Over time, D-Bus/zbus connection logic and proxy instantiation became duplicated and spread across various workspace crates (`asusctl`, `rog-control-center`, `asus-shutdown`), rather than leveraging `rog-dbus` as the single source of truth.

### Why this is needed:
Beyond code duplication, creating uncoordinated D-Bus connections across modules introduced several runtime risks and issues:
1. **File Descriptor & Connection Leaks**: Repeated calls to `Connection::system()` in polling loops accumulated Unix domain sockets and `eventfd` handles until exhausting OS file descriptor limits (`EMFILE`).
2. **Cache Drift & State Inconsistency**: Independent `zbus` proxy instances did not share property caches or signal invalidations, risking stale reads across concurrent UI/CLI tasks.
3. **Non-deterministic Device Selection & Race Conditions**: Inconsistent device discovery ordering (e.g. byte-order string sorting where `/.../10` preceded `/.../2`) could result in different components selecting different devices as primary.
4. **D-Bus Broker Overhead**: Spawning multiple connections multiplied authentication handshakes and duplicate match rules in `dbus-daemon`.

### Summary of Changes:
- **`rog-dbus`**:
  - **Shared Connection Singletons**: Centralized process-wide async (`system_connection` via `tokio::sync::OnceCell`) and blocking (`system_connection_blocking` via `std::sync::OnceLock`) system connections.
  - **Typed Proxy Factories & Discoverers**: Re-exported all proxies at crate root and added unified typed constructors (`platform_proxy`, `fan_curves_proxy`, `backlight_proxy`) and device discovery helpers (`find_armoury_proxies`, `find_aura_proxies`, `find_slash_proxies`, `find_anime_proxies`, `find_xgm_led_proxies`, `find_scsi_aura_proxies`).
  - **Natural Path Sorting**: Added `cmp_object_paths` to ensure numerical ordering for trailing object path segments with byte-order fallback.
- **`rog-control-center`**: Migrated UI setup modules (`setup_fans`, `setup_system`, `setup_gpu`, `setup_aura`, `setup_slash`, `setup_anime`) to use the centralized helpers and shared connection.
- **`asusctl` & `asus-shutdown`**: Updated CLI handlers and shutdown cleanup to use centralized blocking proxy factories.

## Tested Hardware & Environment

- **ASUS Laptop Model:** ASUS ROG Strix G614PR
- **Linux Distribution:** CachyOS
- **Kernel Version:** 7.2.0-1-cachyos

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)