### PR TITLE
fix(asusd): re-apply fan curves after every platform profile write

### DIFF
--- a/asusd/src/ctrl_platform.rs
+++ b/asusd/src/ctrl_platform.rs
@@ -167,15 +167,13 @@ impl CtrlPlatform {
         }
     }
 
-    /// Re-apply fan curves for the given profile, then write PPT values.
-    /// Fan curves must be applied first because PPT writes require the EC
-    /// to be in Manual fan mode (FANM=4), which is set by fan curve writes.
-    async fn apply_fan_curves_and_ppt(
-        &self,
-        attrs: &FirmwareAttributes,
-        power_plugged: bool,
-        profile: PlatformProfile,
-    ) {
+    /// Re-apply the custom fan curves for the given profile.
+    ///
+    /// Writing the platform profile makes the kernel disable every custom fan
+    /// curve at once, so this must follow every such write. Writing the same
+    /// profile value still disables them while emitting no change event, so the
+    /// platform profile watcher cannot be relied on to notice.
+    async fn reapply_fan_curves(&self, profile: PlatformProfile) {
         if let Some(ref fc_config) = self.fan_curve_config {
             let mut fc = fc_config.lock().await;
             if let Ok(mut device) = find_fan_curve_node() {
@@ -186,6 +184,32 @@ impl CtrlPlatform {
             }
             fc.current = profile;
         }
+    }
+
+    /// Write the platform profile and restore the fan curves it just wiped.
+    ///
+    /// This is the only sanctioned way to set the profile from this type;
+    /// calling `self.platform.set_platform_profile()` directly leaves the
+    /// custom fan curves disabled.
+    async fn write_platform_profile(
+        &self,
+        profile: PlatformProfile,
+    ) -> Result<(), rog_platform::error::PlatformError> {
+        self.platform.set_platform_profile(profile.into())?;
+        self.reapply_fan_curves(profile).await;
+        Ok(())
+    }
+
+    /// Re-apply fan curves for the given profile, then write PPT values.
+    /// Fan curves must be applied first because PPT writes require the EC
+    /// to be in Manual fan mode (FANM=4), which is set by fan curve writes.
+    async fn apply_fan_curves_and_ppt(
+        &self,
+        attrs: &FirmwareAttributes,
+        power_plugged: bool,
+        profile: PlatformProfile,
+    ) {
+        self.reapply_fan_curves(profile).await;
         set_config_or_default(
             attrs,
             &mut *self.config.lock().await,
@@ -357,7 +381,7 @@ impl CtrlPlatform {
         let throttle = self.select_power_profile_for_source(power_plugged).await;
         debug!("Setting {throttle:?} before EPP");
         let epp = self.get_config_epp_for_throttle(throttle).await;
-        if let Err(err) = self.platform.set_platform_profile(throttle.into()) {
+        if let Err(err) = self.write_platform_profile(throttle).await {
             warn!("Failed to set platform profile {throttle:?} on AC/BAT change: {err}");
             return;
         }
@@ -487,12 +511,10 @@ impl CtrlPlatform {
             let change_epp = self.config.lock().await.platform_profile_linked_epp;
             let epp = self.get_config_epp_for_throttle(policy).await;
             self.check_and_set_epp(epp, change_epp);
-            self.platform
-                .set_platform_profile(policy.into())
-                .map_err(|err| {
-                    warn!("platform_profile {}", err);
-                    FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
-                })?;
+            self.write_platform_profile(policy).await.map_err(|err| {
+                warn!("platform_profile {}", err);
+                FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
+            })?;
             self.enable_ppt_group_changed(&ctxt).await?;
             Ok(self.platform_profile_changed(&ctxt).await?)
         } else {
@@ -536,12 +558,10 @@ impl CtrlPlatform {
                 )));
             }
 
-            self.platform
-                .set_platform_profile(policy.into())
-                .map_err(|err| {
-                    warn!("platform_profile {}", err);
-                    FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
-                })?;
+            self.write_platform_profile(policy).await.map_err(|err| {
+                warn!("platform_profile {}", err);
+                FdoErr::Failed(format!("RogPlatform: platform_profile: {err}"))
+            })?;
             self.enable_ppt_group_changed(&ctxt).await?;
             Ok(())
         } else {
@@ -767,7 +787,7 @@ impl CtrlPlatform {
             .await;
         } else {
             // reapply the profile to ensure acpi resets PPT to defaults
-            self.platform.set_platform_profile(profile.into())?;
+            self.write_platform_profile(profile).await?;
         }
 
         // Re-emit armoury attribute limits so GUI sees updated min/max for PPT


### PR DESCRIPTION
# Description

I went digging into why my custom fan curves kept quietly reverting to the factory curve, and it turns out that any write to the platform profile makes the kernel disable all of them. `fan_curve_enable_store()` in `asus-wmi.c` takes the disable path into `throttle_thermal_policy_write()`, which clears `enabled` on every fan curve device at once. That is what the "the kernel currently resets *all* if one is" comment over in `rog-profiles` is talking about. asusd only re-applies the curves in the AC/DC handler and in the platform profile watcher, so every other profile write leaves them disabled while the config still reports them as enabled.

The practical result is that the curves get dropped on every daemon start. `start_tasks()` calls `CtrlPlatform::reload()`, which calls `update_policy_ac_or_bat()` and writes the profile a couple of milliseconds after `CtrlFanCurveZbus::reload()` had just enabled them. Nothing puts them back afterwards, and since asusd set the profile itself there is no change event for the watcher to pick up. Here is an unpatched start on 6.4.0, timestamps trimmed to the fractional part:

```text
.336844  write_profile_curve_to_platform  CPU
.337258  write_profile_curve_to_platform  GPU
.337681  FanCurves: initialized
.339480  CtrlPlatform: initialized
.342134  ThrottlePolicy setting EPP
.346891  CtrlPlatform: tasks started
```

Note the empty gap between the policy write and `tasks started`. After that `pwm1_enable` and `pwm2_enable` both read 2, the EC is back on its factory curve, and `asusctl fan-curve --mod-profile performance` still cheerfully reports `enabled: true`. One detail that cost me a while during debugging: the curve point read-back keeps showing the custom curve because that is the driver's cached copy, so `pwm*_enable` is the only thing worth trusting there.

`enable_ppt_group()` runs into the same problem from a different direction. It rewrites the same profile value on purpose so that ACPI resets PPT to defaults, which disables the curves, and because the value did not actually change there is nothing for the watcher to notice either.

There are four `set_platform_profile()` call sites in `ctrl_platform.rs` and only one of them was paired with a re-apply, so rather than adding a fourth pairing I pulled the curve half of `apply_fan_curves_and_ppt()` out into `reapply_fan_curves()` and added `write_platform_profile()`, which writes the profile and then restores the curves. All four sites go through it now, which leaves exactly one direct `self.platform.set_platform_profile()` call in the file and makes the invariant harder to lose by accident later.

I deliberately left the existing `apply_fan_curves_and_ppt()` calls alone, even though two of them now end up writing the curve twice in a row. That bundle carries the ordering constraint described in its own doc comment, since PPT writes need Manual fan mode and a curve write is what establishes it, and `update_policy_ac_or_bat()` can return early without writing anything at all when `change_platform_profile_on_ac` or `_on_battery` is false, which would leave a bare PPT write with no curve write ahead of it. The watcher call is not duplication in the first place: it covers profile writes made by other processes such as power-profiles-daemon or a desktop power applet, which asusd has no way to intercept.

#136 and #196 look like the same behaviour seen from the user side, and both were closed as duplicates of #162, which may well be hitting this too. No Fixes line since I cannot test that hardware.

## Tested Hardware & Environment

- **ASUS Laptop Model:** TUF Gaming A15 FA507UV
- **Linux Distribution:** NixOS unstable
- **Kernel Version:** 7.1.8-xanmod1

<!-- If this is a work in progress (WIP), please check the draft box and list the tasks below: -->
<!-- 
# TODO
- [ ] Task
-->

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings`/`cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)
