### PR TITLE
fix(rog-aura): add logo power zone for G615LR

### DIFF
--- a/rog-aura/data/aura_support.ron
+++ b/rog-aura/data/aura_support.ron
@@ -501,7 +501,7 @@
         basic_modes: [Static, Breathe, RainbowCycle, RainbowWave],
         basic_zones: [Key1, Key2, Key3, Key4],
         advanced_type: r#None,
-        power_zones: [Keyboard, Lightbar],
+        power_zones: [Keyboard, Lightbar, Logo],
     ),
     (
         device_name: "G634J",


### PR DESCRIPTION
# Description

Declare the existing `Logo` power zone for the G615LR Aura configuration.

The G615LR lid logo uses the already implemented Logo protocol bits, but the model support entry only exposed Keyboard and Lightbar. No protocol changes are required.

## Tested Hardware & Environment

- **ASUS Laptop Model:** ROG Strix G16 G615LR_G615LR
- **Board Name:** G615LR
- **Aura USB Controller:** 0b05:19b6
- **Linux Distribution:** NixOS 26.11 (Zokor)
- **Kernel Version:** 7.2.0
- **asusctl Version:** 6.4.0

## Hardware verification

- Confirmed `Supported Aura Power Zones` changed from `Keyboard, Lightbar` to `Keyboard, Lightbar, Logo`.
- Confirmed `asusctl aura power logo --awake` enables the lid logo.
- Confirmed the logo follows the global Aura effect by setting the static colour to red.
- Confirmed the Lightbar remains independently disabled while the Logo is enabled.

## AI disclosure

AI assistance was used to trace the existing `PowerZones::Logo` implementation and prepare the initial diagnosis. I reviewed the one-line change, built it locally, and personally performed the hardware verification described above.

# Verification and testing

- [x] I have performed a self-review of my code
- [x] Comments are not applicable because this is a one-line support-data change
- [x] Documentation changes are not required for this model capability correction
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-targets`
- [x] `cargo test --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo cranky`
