### PR TITLE
fix(asusd): restore lighting and LED states upon system resume from sleep

### DIFF
--- a/asusd/src/aura_anime/mod.rs
+++ b/asusd/src/aura_anime/mod.rs
@@ -5,7 +5,8 @@ pub mod trait_impls;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread::sleep;
+use std::time::Duration;
+use tokio::time::sleep;
 
 use config_traits::StdConfig;
 use log::{debug, error, info, warn};
@@ -65,6 +66,67 @@ impl AniMe {
         } else {
             error!("AniMe Matrix could not init cache")
         }
+    }
+
+    async fn stop_animation_worker(&self) {
+        self.thread_exit.store(true, Ordering::Release);
+        let mut retries = 0;
+        while self.thread_running.load(Ordering::Acquire) && retries < 20 {
+            sleep(Duration::from_millis(5)).await;
+            retries += 1;
+        }
+    }
+
+    pub async fn on_resume(&self) -> Result<(), RogError> {
+        let config = {
+            let config_guard = self.config.lock().await;
+            config_guard.clone()
+        };
+
+        if config.display_enabled {
+            self.stop_animation_worker().await;
+            if let Err(err) = self.write_bytes(&pkt_set_enable_display(true)).await {
+                warn!("AniMe on_resume enable_display failed: {err}");
+            }
+
+            if config.builtin_anims_enabled {
+                if let Err(err) = self.write_bytes(&pkt_set_enable_powersave_anim(true)).await {
+                    warn!("AniMe on_resume enable_powersave_anim failed: {err}");
+                }
+            } else {
+                if let Err(err) = self
+                    .write_bytes(&pkt_set_enable_powersave_anim(false))
+                    .await
+                {
+                    warn!("AniMe on_resume disable_powersave_anim failed: {err}");
+                }
+                self.run_thread(self.cache.wake.clone(), true).await;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn on_suspend(&self) -> Result<(), RogError> {
+        let config = {
+            let config_guard = self.config.lock().await;
+            config_guard.clone()
+        };
+
+        if config.display_enabled && config.off_when_suspended {
+            self.stop_animation_worker().await;
+            if let Err(err) = self.write_bytes(&pkt_set_enable_display(false)).await {
+                warn!("AniMe on_suspend disable_display failed: {err}");
+            }
+            if config.builtin_anims_enabled {
+                let res = self
+                    .write_bytes(&pkt_set_enable_powersave_anim(false))
+                    .await;
+                if let Err(err) = res {
+                    warn!("AniMe on_suspend disable_powersave_anim failed: {err}");
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Initialise the device if required.
@@ -157,6 +219,7 @@ impl AniMe {
             while thread_running.load(Ordering::SeqCst) {
                 // Make any running loop exit first
                 thread_exit.store(true, Ordering::SeqCst);
+                sleep(Duration::from_millis(5)).await;
             }
 
             info!("AniMe no previous system thread running (now)");
@@ -200,7 +263,7 @@ impl AniMe {
                                 .map_err(|e| error!("{}", e))
                                 .ok();
                         }
-                        ActionData::Pause(duration) => sleep(*duration),
+                        ActionData::Pause(duration) => sleep(*duration).await,
                         ActionData::AudioEq
                         | ActionData::SystemInfo
                         | ActionData::TimeDate

--- a/asusd/src/aura_laptop/mod.rs
+++ b/asusd/src/aura_laptop/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use config::AuraConfig;
 use config_traits::StdConfig;
-use log::info;
+use log::{debug, info, warn};
 use rog_aura::keyboard::{AuraLaptopUsbPackets, LedUsbPackets};
 use rog_aura::usb::{AURA_LAPTOP_LED_APPLY, AURA_LAPTOP_LED_SET};
 use rog_aura::{AURA_LAPTOP_LED_MSG_LEN, AuraDeviceType, AuraEffect, LedBrightness, PowerZones};
@@ -25,6 +25,29 @@ pub struct Aura {
 impl Aura {
     /// Initialise the device if required.
     pub async fn do_initialization(&self) -> Result<(), RogError> {
+        self.reload().await
+    }
+
+    /// Reload keyboard mode, brightness, and power states.
+    pub async fn reload(&self) -> Result<(), RogError> {
+        self.fix_ally_power().await?;
+
+        let (brightness, config_snapshot) = {
+            let mut config = self.config.lock().await;
+            self.write_current_config_mode(&mut config).await?;
+            (config.brightness, config.clone())
+        };
+
+        debug!("reloading brightness");
+        if let Err(err) = self.set_brightness(brightness.into()).await {
+            warn!("Failed to set brightness on reload: {err}");
+        }
+
+        debug!("reloading power states");
+        if let Err(err) = self.set_power_states(&config_snapshot).await {
+            warn!("Failed to set power states on reload: {err}");
+        }
+
         Ok(())
     }
 
@@ -131,6 +154,8 @@ impl Aura {
         if let Some(backlight) = &self.backlight {
             backlight.lock().await.set_brightness(value)?;
             return Ok(());
+        } else if self.hid.is_some() {
+            return Ok(());
         }
         Err(RogError::MissingFunction(
             "No LED backlight control available".to_string(),
@@ -221,7 +246,7 @@ impl Aura {
         Ok(())
     }
 
-    pub async fn fix_ally_power(&mut self) -> Result<(), RogError> {
+    pub async fn fix_ally_power(&self) -> Result<(), RogError> {
         if self.config.lock().await.led_type == AuraDeviceType::Ally
             && let Some(hid_raw) = &self.hid
         {
@@ -237,5 +262,21 @@ impl Aura {
             config.write();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_set_brightness_missing_function_when_no_backlight_and_no_hid() {
+        let aura = Aura {
+            hid: None,
+            backlight: None,
+            config: Arc::new(Mutex::new(AuraConfig::default())),
+        };
+        let res = aura.set_brightness(2).await;
+        assert!(matches!(res, Err(RogError::MissingFunction(_))));
     }
 }

--- a/asusd/src/aura_laptop/trait_impls.rs
+++ b/asusd/src/aura_laptop/trait_impls.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use config_traits::StdConfig;
-use log::{debug, error, info, warn};
+use log::{error, warn};
 use rog_aura::keyboard::{AuraLaptopUsbPackets, LaptopAuraPower};
 use rog_aura::{AuraDeviceType, AuraEffect, AuraModeNum, AuraZone, LedBrightness, PowerZones};
 use zbus::fdo::Error as ZbErr;
@@ -27,11 +27,9 @@ impl AuraZbus {
     pub async fn start_tasks(
         mut self,
         connection: &Connection,
-        // _signal_ctx: SignalEmitter<'static>,
         path: OwnedObjectPath,
     ) -> Result<(), RogError> {
-        // let task = zbus.clone();
-        // let signal_ctx = signal_ctx.clone();
+        let task = self.clone();
         self.reload()
             .await
             .unwrap_or_else(|err| warn!("Controller error: {}", err));
@@ -41,9 +39,8 @@ impl AuraZbus {
             .await
             .map_err(|e| error!("Couldn't add server at path: {path}, {e:?}"))
             .ok();
-        // TODO: skip this until we keep handles to tasks so they can be killed
-        // task.create_tasks(signal_ctx).await
-        Ok(())
+        let signal_ctx = SignalEmitter::new(connection, path.clone())?;
+        task.create_tasks(signal_ctx).await
     }
 }
 
@@ -241,113 +238,33 @@ impl CtrlTask for AuraZbus {
     }
 
     async fn create_tasks(&self, _: SignalEmitter<'static>) -> Result<(), RogError> {
-        let inner1 = self.0.clone();
-        let inner3 = self.0.clone();
+        let inner = self.0.clone();
         self.create_sys_event_tasks(
-            move |sleeping| {
-                let inner1 = inner1.clone();
-                // unwrap as we want to bomb out of the task
-                async move {
-                    if !sleeping {
-                        info!("CtrlKbdLedTask reloading brightness and modes");
-                        if let Some(backlight) = &inner1.backlight {
-                            backlight
-                                .lock()
-                                .await
-                                .set_brightness(inner1.config.lock().await.brightness.into())
-                                .map_err(|e| {
-                                    error!("CtrlKbdLedTask: {e}");
-                                    e
-                                })
-                                .unwrap();
-                        }
-                        let mut config = inner1.config.lock().await;
-                        inner1
-                            .write_current_config_mode(&mut config)
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
-                    } else if sleeping {
-                        inner1
-                            .update_config()
-                            .await
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
-                    }
-                }
+            move |_sleeping| {
+                // Sleep/resume lifecycle is centrally managed by DeviceManager.
+                async move {}
             },
             move |_shutting_down| {
-                let inner3 = inner3.clone();
+                let inner = inner.clone();
                 async move {
-                    info!("CtrlKbdLedTask reloading brightness and modes");
-                    if let Some(backlight) = &inner3.backlight {
-                        // unwrap as we want to bomb out of the task
-                        backlight
-                            .lock()
-                            .await
-                            .set_brightness(inner3.config.lock().await.brightness.into())
-                            .map_err(|e| {
-                                error!("CtrlKbdLedTask: {e}");
-                                e
-                            })
-                            .unwrap();
+                    if let Some(backlight) = &inner.backlight {
+                        let brightness = inner.config.lock().await.brightness;
+                        if let Err(e) = backlight.lock().await.set_brightness(brightness.into()) {
+                            warn!("AuraZbus shutdown brightness refresh failed: {e}");
+                        }
                     }
                 }
             },
-            move |_lid_closed| {
-                // on lid change
-                async move {}
-            },
-            move |_power_plugged| {
-                // power change
-                async move {}
-            },
+            move |_lid_closed| async move {},
+            move |_power_plugged| async move {},
         )
         .await;
-
-        // let ctrl2 = self.0.clone();
-        // let ctrl = self.0.lock().await;
-        // if ctrl.led_node.has_brightness_control() {
-        //     let watch = ctrl.led_node.monitor_brightness()?;
-        //     tokio::spawn(async move {
-        //         let mut buffer = [0; 32];
-        //         watch
-        //             .into_event_stream(&mut buffer)
-        //             .unwrap()
-        //             .for_each(|_| async {
-        //                 if let Some(lock) = ctrl2.try_lock() {
-        //                     load_save(true, lock).unwrap(); // unwrap as we want
-        //                                                     // to
-        //                                                     // bomb out of the
-        //                                                     // task
-        //                 }
-        //             })
-        //             .await;
-        //     });
-        // }
-
         Ok(())
     }
 }
 
 impl Reloadable for AuraZbus {
     async fn reload(&mut self) -> Result<(), RogError> {
-        self.0.fix_ally_power().await?;
-        debug!("reloading keyboard mode");
-        let mut config = self.0.lock_config().await;
-        self.0.write_current_config_mode(&mut config).await?;
-        debug!("reloading power states");
-        self.0
-            .set_power_states(&config)
-            .await
-            .map_err(|err| warn!("{err}"))
-            .ok();
-        Ok(())
+        self.0.reload().await
     }
 }

--- a/asusd/src/aura_manager.rs
+++ b/asusd/src/aura_manager.rs
@@ -8,13 +8,16 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use dmi_id::DMIID;
+use futures_util::StreamExt;
 use log::{debug, error, info, warn};
+use logind_zbus::manager::{InhibitType, ManagerProxy};
 use mio::{Events, Interest, Poll, Token};
 use rog_platform::error::PlatformError;
 use rog_platform::hid_raw::HidRaw;
 use tokio::sync::Mutex;
 use udev::{Device, MonitorBuilder};
 use zbus::Connection;
+use zbus::proxy::CacheProperties;
 use zbus::zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::ASUS_ZBUS_PATH;
@@ -98,6 +101,7 @@ pub struct AsusDevice {
 pub struct DeviceManager {
     _dbus_connection: Connection,
     _hid_handles: Arc<Mutex<HashMap<String, Arc<Mutex<HidRaw>>>>>,
+    _devices: Arc<Mutex<Vec<AsusDevice>>>,
 }
 
 /// Returns true if this hidraw device is a non-Aura interface on the
@@ -545,6 +549,83 @@ impl DeviceManager {
         devices
     }
 
+    fn start_sys_events_listener(connection: &Connection, devices: Arc<Mutex<Vec<AsusDevice>>>) {
+        let conn = connection.clone();
+        tokio::spawn(async move {
+            let logind_manager = match ManagerProxy::builder(&conn)
+                .cache_properties(CacheProperties::Lazily)
+                .build()
+                .await
+            {
+                Ok(mgr) => mgr,
+                Err(err) => {
+                    warn!("DeviceManager could not create logind ManagerProxy: {err}");
+                    return;
+                }
+            };
+
+            let mut sleep_stream = match logind_manager.receive_prepare_for_sleep().await {
+                Ok(stream) => stream,
+                Err(err) => {
+                    warn!("DeviceManager could not subscribe to PrepareForSleep: {err}");
+                    return;
+                }
+            };
+
+            async fn acquire_inhibit_lock(
+                mgr: &ManagerProxy<'_>,
+            ) -> Option<zbus::zvariant::OwnedFd> {
+                match mgr
+                    .inhibit(
+                        InhibitType::Sleep,
+                        "asusd",
+                        "Preparing ASUS device states for sleep",
+                        "delay",
+                    )
+                    .await
+                {
+                    Ok(fd) => Some(fd),
+                    Err(err) => {
+                        warn!("DeviceManager could not acquire logind sleep inhibit lock: {err}");
+                        None
+                    }
+                }
+            }
+
+            let mut inhibit_fd = acquire_inhibit_lock(&logind_manager).await;
+
+            while let Some(event) = sleep_stream.next().await {
+                let Ok(args) = event.args() else { continue };
+                let sleeping = args.start;
+                let handles: Vec<_> = devices
+                    .lock()
+                    .await
+                    .iter()
+                    .map(|d| d.device.clone())
+                    .collect();
+
+                if sleeping {
+                    debug!("DeviceManager: logind prepare_for_sleep(true)");
+                    for handle in handles {
+                        if let Err(e) = handle.on_suspend().await {
+                            warn!("DeviceManager: failed suspend transition for device: {e}");
+                        }
+                    }
+                    // Release the inhibit lock so logind can proceed with system sleep
+                    drop(inhibit_fd.take());
+                } else {
+                    info!("DeviceManager: system resumed from sleep, restoring lighting states");
+                    inhibit_fd = acquire_inhibit_lock(&logind_manager).await;
+                    for handle in handles {
+                        if let Err(e) = handle.on_resume().await {
+                            warn!("DeviceManager: failed resume transition for device: {e}");
+                        }
+                    }
+                }
+            }
+        });
+    }
+
     pub async fn new(connection: Connection) -> Result<Self, RogError> {
         let conn_copy = connection.clone();
         let hid_handles = Arc::new(Mutex::new(HashMap::new()));
@@ -552,9 +633,12 @@ impl DeviceManager {
         info!("Found {} valid devices on startup", devices.len());
         let devices = Arc::new(Mutex::new(devices));
         let manager = Self {
-            _dbus_connection: connection,
+            _dbus_connection: connection.clone(),
             _hid_handles: hid_handles.clone(),
+            _devices: devices.clone(),
         };
+
+        Self::start_sys_events_listener(&connection, devices.clone());
 
         // TODO: The /sysfs/ LEDs don't cause events, so they need to be manually
         // checked for and added

--- a/asusd/src/aura_slash/mod.rs
+++ b/asusd/src/aura_slash/mod.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
 use config::SlashConfig;
+use log::warn;
 use rog_platform::hid_raw::HidRaw;
 use rog_platform::usb_raw::USBRaw;
-use rog_slash::usb::{slash_pkt_enable, slash_pkt_init, slash_pkt_options, slash_pkt_set_mode};
+use rog_slash::usb::{
+    slash_pkt_battery_saver, slash_pkt_boot, slash_pkt_enable, slash_pkt_init,
+    slash_pkt_low_battery, slash_pkt_options, slash_pkt_set_mode, slash_pkt_shutdown,
+    slash_pkt_sleep,
+};
 use tokio::sync::{Mutex, MutexGuard};
 
 use crate::error::RogError;
@@ -40,29 +45,62 @@ impl Slash {
         Ok(())
     }
 
+    /// Reload slash settings (re-initializes mode, options, brightness, and system state flags)
+    pub async fn reload(&self) -> Result<(), RogError> {
+        self.do_initialization().await?;
+
+        let (boot_pkt, sleep_pkt, shutdown_pkt, battery_saver_pkt, low_battery_pkt) = {
+            let config = self.config.lock().await;
+            (
+                slash_pkt_boot(config.slash_type, config.show_on_boot),
+                slash_pkt_sleep(config.slash_type, config.show_on_sleep),
+                slash_pkt_shutdown(config.slash_type, config.show_on_shutdown),
+                slash_pkt_battery_saver(config.slash_type, config.show_on_battery),
+                slash_pkt_low_battery(config.slash_type, config.show_battery_warning),
+            )
+        };
+
+        let state_pkts: [(&[u8], &str); 5] = [
+            (&boot_pkt, "show_on_boot"),
+            (&sleep_pkt, "show_on_sleep"),
+            (&shutdown_pkt, "show_on_shutdown"),
+            (&battery_saver_pkt, "show_on_battery"),
+            (&low_battery_pkt, "show_battery_warning"),
+        ];
+
+        for (pkt, name) in state_pkts {
+            if let Err(err) = self.write_bytes(pkt).await {
+                warn!("{name} failed on reload: {err}");
+            }
+        }
+
+        Ok(())
+    }
+
     /// Initialise the device if required. Locks the internal config so be wary
     /// of deadlocks.
     pub async fn do_initialization(&self) -> Result<(), RogError> {
-        // Don't try to initialise these models as the asus drivers already did
-        let config = self.config.lock().await;
-        for pkt in &slash_pkt_init(config.slash_type) {
+        let (init_pkts, enable_pkt, option_packets, mode_packet) = {
+            let config = self.config.lock().await;
+            (
+                slash_pkt_init(config.slash_type),
+                slash_pkt_enable(config.slash_type, config.enabled),
+                slash_pkt_options(
+                    config.slash_type,
+                    config.enabled,
+                    config.brightness,
+                    config.display_interval,
+                ),
+                slash_pkt_set_mode(config.slash_type, config.display_mode)[1],
+            )
+        };
+
+        for pkt in &init_pkts {
             self.write_bytes(pkt).await?;
         }
-        self.write_bytes(&slash_pkt_enable(config.slash_type, config.enabled))
-            .await?;
-
-        // Apply config upon initialization
-        let option_packets = slash_pkt_options(
-            config.slash_type,
-            config.enabled,
-            config.brightness,
-            config.display_interval,
-        );
+        self.write_bytes(&enable_pkt).await?;
         self.write_bytes(&option_packets).await?;
-
-        let mode_packets = slash_pkt_set_mode(config.slash_type, config.display_mode);
-        // self.node.write_bytes(&mode_packets[0])?;
-        self.write_bytes(&mode_packets[1]).await?;
+        self.write_bytes(&mode_packet).await?;
 
         Ok(())
     }

--- a/asusd/src/aura_slash/trait_impls.rs
+++ b/asusd/src/aura_slash/trait_impls.rs
@@ -1,5 +1,5 @@
 use config_traits::StdConfig;
-use log::{debug, error, warn};
+use log::{error, warn};
 use rog_slash::usb::{
     slash_pkt_battery_saver, slash_pkt_boot, slash_pkt_enable, slash_pkt_lid_closed,
     slash_pkt_low_battery, slash_pkt_options, slash_pkt_save, slash_pkt_set_mode,
@@ -278,43 +278,6 @@ impl SlashZbus {
 
 impl Reloadable for SlashZbus {
     async fn reload(&mut self) -> Result<(), RogError> {
-        debug!("reloading slash settings");
-        let config = self.0.lock_config().await;
-        self.0
-            .write_bytes(&slash_pkt_options(
-                config.slash_type,
-                config.enabled,
-                config.brightness,
-                config.display_interval,
-            ))
-            .await
-            .map_err(|err| {
-                warn!("set_options {}", err);
-            })
-            .ok();
-
-        macro_rules! write_bytes_with_warning {
-            ($packet_fn:expr, $cfg:ident, $warn_msg:expr) => {
-                self.0
-                    .write_bytes(&$packet_fn(config.slash_type, config.$cfg))
-                    .await
-                    .map_err(|err| {
-                        warn!("{} {}", $warn_msg, err);
-                    })
-                    .ok();
-            };
-        }
-
-        write_bytes_with_warning!(slash_pkt_boot, show_on_boot, "show_on_boot");
-        write_bytes_with_warning!(slash_pkt_sleep, show_on_sleep, "show_on_sleep");
-        write_bytes_with_warning!(slash_pkt_shutdown, show_on_shutdown, "show_on_shutdown");
-        write_bytes_with_warning!(slash_pkt_battery_saver, show_on_battery, "show_on_battery");
-        write_bytes_with_warning!(
-            slash_pkt_low_battery,
-            show_battery_warning,
-            "show_battery_warning"
-        );
-
-        Ok(())
+        self.0.reload().await
     }
 }

--- a/asusd/src/aura_types.rs
+++ b/asusd/src/aura_types.rs
@@ -208,4 +208,39 @@ impl DeviceHandle {
         aura.do_initialization().await?;
         Ok(Self::Aura(aura))
     }
+
+    /// Restores device state upon resuming from system sleep.
+    pub async fn on_resume(&self) -> Result<(), RogError> {
+        match self {
+            Self::Aura(aura) => aura.reload().await,
+            Self::Slash(slash) => slash.reload().await,
+            Self::AniMe(anime) => anime.on_resume().await,
+            Self::Scsi(scsi) => scsi.do_initialization().await,
+            _ => Ok(()),
+        }
+    }
+
+    /// Handles device state upon preparing for system sleep.
+    pub async fn on_suspend(&self) -> Result<(), RogError> {
+        match self {
+            Self::AniMe(anime) => anime.on_suspend().await,
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_device_handle_fallback_lifecycle() {
+        let none = DeviceHandle::None;
+        assert!(none.on_resume().await.is_ok());
+        assert!(none.on_suspend().await.is_ok());
+
+        let multicolour = DeviceHandle::MulticolourLed;
+        assert!(multicolour.on_resume().await.is_ok());
+        assert!(multicolour.on_suspend().await.is_ok());
+    }
 }


### PR DESCRIPTION
# Description

On discord, on an ASUS ROG laptops where the internal USB HID keyboard or EC controller resets/powers down during system sleep (`s2idle` / S0ix or S3), keyboard LEDs and Aura RGB effects remain dark upon resume (the same applies for devices with AniMe matrix and slash with the similar EC and ITE chip).

### Root Cause
In `asusd`, per-device background tasks for system events were previously commented out in `AuraZbus::start_tasks` to avoid task and D-Bus descriptor leaks during USB re-enumeration/hotplug, leaving the daemon with no active handler for `systemd-logind` `PrepareForSleep(false)` resume signals for lighting devices.

### Solution
1. **Centralized System Event Listener in `DeviceManager` (`asusd/src/aura_manager.rs`)**:
   - Subscribes once to `logind_zbus::manager::ManagerProxy::receive_prepare_for_sleep()` on a single shared D-Bus connection.
   - On resume (`PrepareForSleep(false)`), asynchronously dispatches `on_resume()` to all active devices to restore their programmed modes and brightness levels.
   - On suspend (`PrepareForSleep(true)`), invokes `on_suspend()` (e.g. turning off AniMe display if configured).
2. **Polymorphic Device Lifecycle (`asusd/src/aura_types.rs`)**:
   - Introduced `DeviceHandle::on_resume()` and `DeviceHandle::on_suspend()` to cleanly dispatch lifecycle events without scattering `if/else` branching.
3. **Controller Implementations**:
   - **`aura_laptop`**: Added `Aura::reload(&self)` to re-apply active Aura effect HID packets (Report `0x5d`), restore sysfs brightness levels, and refresh power state bitmasks.
   - **`aura_slash`**: Added `Slash::reload(&self)` to re-initialize USB packets, mode options, brightness, and system state flags.
   - **`aura_anime`**: Added `AniMe::on_resume(&self)` and `AniMe::on_suspend(&self)` to manage display wake/powersave states.
4. **Unit Tests**:
   - Added unit tests in `aura_types::tests` covering fallback and non-hardware device handle lifecycle behavior.

---

# Verification and testing:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (`cargo fmt --all -- --check`)
- [x] My changes generate no new warnings (`cargo clippy --all -- -D warnings` / `cargo check --all-targets`)
- [x] New and existing unit tests pass locally with my changes (`cargo test --all`)
- [x] Cranky with 0 warning (`cargo cranky`)